### PR TITLE
Move jnlpFileName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
         </plugins>
     </build>
 
+    <properties>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -102,7 +107,7 @@
         <dependency>
             <groupId>com.zenjava</groupId>
             <artifactId>javafx-deploy-lib</artifactId>
-            <version>1.1</version>
+            <version>1.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractBundleMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractBundleMojo.java
@@ -53,6 +53,11 @@ public abstract class AbstractBundleMojo extends AbstractMojo {
     protected File splashImage;
 
     /**
+     * @parameter default-value="launch.jnlp"
+     */
+    protected String jnlpFileName;
+
+    /**
      * @parameter
      */
     protected boolean offlineAllowed;
@@ -181,6 +186,7 @@ public abstract class AbstractBundleMojo extends AbstractMojo {
             appProfile.setSplashImage(splashImage.getName());
         }
 
+        appProfile.setJnlpFileName(jnlpFileName);
         appProfile.setOfflineAllowed(offlineAllowed);
 
         if (jreVersion != null) {

--- a/src/main/java/com/zenjava/javafx/maven/plugin/BuildWebstartMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/BuildWebstartMojo.java
@@ -41,11 +41,6 @@ public class BuildWebstartMojo extends AbstractBundleMojo {
     private File webstartOutputDir;
 
     /**
-     * @parameter default-value="launch.jnlp"
-     */
-    private String jnlpFileName;
-
-    /**
      * @parameter default-value="lib"
      */
     private String webstartLibDir;


### PR DESCRIPTION
Set ApplicationProfile.jnlpFileName
Move jnlpFileName from BuildWebStartMojo to AbstractBundleMojo.
Change dependency to javafx-deploy-lib 1.2-SNAPSHOT (there's a pull
request pending)
applicationProfile.setJnlpFileName in getApplicationProfile()

This fix #13
