### PR TITLE
config parameter for file exclusion when unpacking dependency jars

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/BuildJarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/BuildJarMojo.java
@@ -36,6 +36,13 @@ public class BuildJarMojo extends AbstractBundleMojo {
      * @parameter
      */
     protected String executableJarFileName;
+    
+    /**
+     * Exclude files when unpacking module dependencies
+     * 
+     * @parameter default-value=""
+     */
+    protected String excludes;
 
     /**
      * Compile CSS to binary format
@@ -79,7 +86,8 @@ public class BuildJarMojo extends AbstractBundleMojo {
                 ),
                 goal("unpack-dependencies"),
                 configuration(
-                        element(name("outputDirectory"), "${project.build.directory}/" + subDir)
+                        element(name("outputDirectory"), "${project.build.directory}/" + subDir),
+                        element(name("excludes"), excludes)
                 ),
                 executionEnvironment(
                         project,


### PR DESCRIPTION
Hi,

this would be a nice fix/work-around for [Issue #3 - The files from META-INF (from the Spring jars) overwrite each other in executable jar](https://github.com/zonski/javafx-maven-plugin/issues/3)

at least regarding the signature files that get copied in from library jar files
