### PR TITLE
Configuration option "preloaderClass" added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>com.zenjava</groupId>
             <artifactId>javafx-deploy-lib</artifactId>
-            <version>1.2</version>
+            <version>1.3-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractBundleMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractBundleMojo.java
@@ -89,6 +89,11 @@ public abstract class AbstractBundleMojo extends AbstractMojo {
     protected String mainClass;
 
     /**
+     * @parameter
+     */
+    protected String preloaderClass;
+
+    /**
      * @parameter expression="${java.home}"
      */
     protected String javaHome;
@@ -205,6 +210,9 @@ public abstract class AbstractBundleMojo extends AbstractMojo {
             appProfile.setPermissions(permissions);
         }
 
+        if(preloaderClass!=null){
+            appProfile.setPreLoaderClass(preloaderClass);
+        }
         return appProfile;
     }
 

--- a/src/main/java/com/zenjava/javafx/maven/plugin/BuildJarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/BuildJarMojo.java
@@ -60,7 +60,7 @@ public class BuildJarMojo extends AbstractBundleMojo {
         JfxToolsWrapper jfxTools = getJfxToolsWrapper();
         getLog().debug("Using main class '" + mainClass + "'");
         File classesDir = new File(build.getOutputDirectory());
-        jfxTools.packageAsJar(targetJarFile, classesDir, dependenciesDir, mainClass, css2bin);
+        jfxTools.packageAsJar(targetJarFile, classesDir, dependenciesDir, mainClass, preloaderClass, css2bin);
     }
 
     protected File unpackDependencies() throws MojoExecutionException, MojoFailureException {

--- a/src/main/java/com/zenjava/javafx/maven/plugin/BuildNativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/BuildNativeMojo.java
@@ -93,6 +93,7 @@ public class BuildNativeMojo extends AbstractBundleMojo {
                 nativeReleaseVersion,
                 project.getOrganization() != null ? project.getOrganization().getName() : "Unknown JavaFX Developer",
                 mainClass,
+                preloaderClass,
                 needMenu,
                 needShortcut);
     }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/util/JfxToolsWrapper.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/util/JfxToolsWrapper.java
@@ -60,7 +60,8 @@ public class JfxToolsWrapper {
         invokeStatic(logClass, "setLogger", logger);
     }
 
-    public void packageAsJar(File outputFile, File classesDir, File dependenciesDir, String mainClass, boolean css2bin) throws MojoExecutionException {
+    public void packageAsJar(File outputFile, File classesDir, File dependenciesDir, String mainClass,
+                             String preloaderClass, boolean css2bin) throws MojoExecutionException {
 
         Object params = newInstance(createJarParamsClass);
         invoke(params, "setOutdir", outputFile.getParentFile());
@@ -69,6 +70,10 @@ public class JfxToolsWrapper {
         if( dependenciesDir.exists() ) {
             invoke( params, "addResource", dependenciesDir, "" );
         }
+        if (preloaderClass != null && !preloaderClass.isEmpty()) {
+            invoke(params, "setPreloader", preloaderClass);
+        }
+
         invoke(params, "setApplicationClass", mainClass);
         invoke(params, "setCss2bin", css2bin);
 
@@ -95,13 +100,15 @@ public class JfxToolsWrapper {
 
     public void generateDeploymentPackages(File outputDir, String[] jarResources, String bundleType,
                                            String appDistributionName, String appName, String version, String vendor,
-                                           String mainClass, boolean needMenu, boolean needShortcut)
+                                           String mainClass,String preloaderClass, boolean needMenu,
+                                           boolean needShortcut)
             throws MojoExecutionException {
 
         Object deployParams = newInstance(deployParamsClass);
         invoke(deployParams, "setOutdir", outputDir);
         invoke(deployParams, "setOutfile", appDistributionName);
         invoke(deployParams, "setApplicationClass", mainClass);
+        invoke(deployParams, "setPreloader", preloaderClass);
         invoke(deployParams, "setVerbose", new Class[] { Boolean.TYPE }, verbose);
         invoke(deployParams, "setNeedMenu", needMenu);
         invoke(deployParams, "setNeedShortcut", needShortcut);


### PR DESCRIPTION
This add the configuration property "preloaderClass" which maps to the "JavaFX-Preloader-Class" manifest option of javafx builders.

This pull-request need the changes from that pull-request: https://github.com/zonski/javafx-deploy-lib/pull/2
