### PR TITLE
Modify mojo-executor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
-            <version>2.0</version>
+            <version>2.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Modify mojo-executor version from 2.0 to 2.1.0 to solve missing dependency with Maven 3.1, Java 1.7 and MacOXS 10.9
