### PR TITLE
fix null pointer exception if 'bundleArguments' is not specified

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -259,13 +259,17 @@ public class NativeMojo extends AbstractJfxToolsMojo {
 
             params.put(StandardBundlerParam.APP_RESOURCES.getID(), new RelativeFileSet(jfxAppOutputDir, resourceFiles));
 
-            Collection<String> duplicateKeys = new HashSet<>(params.keySet());
-            duplicateKeys.retainAll(bundleArguments.keySet());
-            if (!duplicateKeys.isEmpty()) {
-                throw new MojoExecutionException("The following keys in <bundleArguments> duplicate other settings, please remove one or the other: " + duplicateKeys.toString());
-            }
+            if (bundleArguments != null && !bundleArguments.isEmpty()) {
+                Collection<String> duplicateKeys = new HashSet<>(params.keySet());
+                duplicateKeys.retainAll(bundleArguments.keySet());
+                if (!duplicateKeys.isEmpty()) {
+                    throw new MojoExecutionException(
+                            "The following keys in <bundleArguments> duplicate other settings, please remove one or the other: "
+                                    + duplicateKeys.toString());
+                }
 
-            params.putAll(bundleArguments);
+                params.putAll(bundleArguments);
+            }
 
             Bundlers bundlers = Bundlers.createBundlersInstance(); // service discovery?
             for (Bundler b : bundlers.getBundlers()) {


### PR DESCRIPTION
This patch solves a possible NullPointerException during the native goal execution.
The exception is triggerd, if not ' bundleArguments' are specified in the pom.xml file.

A possible workaround is to add '<bundleArguments />' to the configuration.
