### PR TITLE
Fix NPE when using jfx:native goal in 8.1.1

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -259,6 +259,10 @@ public class NativeMojo extends AbstractJfxToolsMojo {
 
             params.put(StandardBundlerParam.APP_RESOURCES.getID(), new RelativeFileSet(jfxAppOutputDir, resourceFiles));
 
+            if (bundleArguments == null) {
+            	bundleArguments = new HashMap<String, String>();
+            }
+
             Collection<String> duplicateKeys = new HashSet<>(params.keySet());
             duplicateKeys.retainAll(bundleArguments.keySet());
             if (!duplicateKeys.isEmpty()) {


### PR DESCRIPTION
Hello,

In the first words I would like to thank you for this awesome Maven plugin :)

This pull request is to fix NPE when performing `mvn clean jfx:native`:

My plugin setting:

``` xml
<plugin>
    <groupId>com.zenjava</groupId>
    <artifactId>javafx-maven-plugin</artifactId>
    <version>8.1.1</version>
    <executions>
        <execution>
            <phase>package</phase>
            <goals>
                <goal>jar</goal>
            </goals>
        </execution>
    </executions>
    <configuration>
        <mainClass>WebCamAppLauncher</mainClass>
    </configuration>
</plugin>           
```

Exception I faced:

``` plain
[ERROR] Failed to execute goal com.zenjava:javafx-maven-plugin:8.1.2-SNAPSHOT:native (default-cli) on project webcam-capture-example-javafx: An error occurred while generating native deployment bundles: NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.zenjava:javafx-maven-plugin:8.1.2-SNAPSHOT:native (default-cli) on project webcam-capture-example-javafx: An error occurred while generating native deployment bundles
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:216)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:347)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:154)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:213)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:157)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: An error occurred while generating native deployment bundles
    at com.zenjava.javafx.maven.plugin.NativeMojo.execute(NativeMojo.java:294)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
    ... 19 more
Caused by: java.lang.NullPointerException
    at com.zenjava.javafx.maven.plugin.NativeMojo.execute(NativeMojo.java:267)
    ... 21 more
```

I tested this fix and was able to generate `*.deb` and `*.rpm` packages successfully.

Thanks!
