### PR TITLE
Add all files from jfxAppOutputDir to application resources

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -238,23 +238,17 @@ public class NativeMojo extends AbstractJfxToolsMojo {
             }
 
             Set<File> resourceFiles = new HashSet<>();
-
-            resourceFiles.add(new File(jfxAppOutputDir, jfxMainAppJarName));
-
-            File libDir = new File(jfxAppOutputDir, "lib");
-            if (libDir.exists() && libDir.list().length > 0) {
-                try {
-                    Files.walk(libDir.toPath())
-                        .forEach(p -> {
-                            File f = p.toFile();
-                            System.out.println(p.toFile());
-                            if (f.isFile()) {
-                                resourceFiles.add(p.toFile());
-                            }
-                        });
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+            try {
+                Files.walk(jfxAppOutputDir.toPath())
+                    .forEach(p -> {
+                        File f = p.toFile();
+                        if (f.isFile()) {
+                            getLog().info(String.format("Add %s file to application resources.", p.toFile()));
+                            resourceFiles.add(p.toFile());
+                        }
+                    });
+            } catch (IOException e) {
+                e.printStackTrace();
             }
 
             params.put(StandardBundlerParam.APP_RESOURCES.getID(), new RelativeFileSet(jfxAppOutputDir, resourceFiles));


### PR DESCRIPTION
Hi,

I want to add license file to native package but I can't do it because I see the following error message:

~~~
[INFO] Skipping DMG Installer because of configuration error Specified license file is missing.
Advice to Fix: Make sure that "LICENSE" references a file in the app resources, and that it is relative to the basedir "<app dir>/target/jfx/app".
~~~

because LICENSE file [is not a part of application resources](https://github.com/Debian/openjfx/blob/master/modules/fxpackager/src/main/java/com/oracle/tools/packager/mac/MacDmgBundler.java#L482).

So, I think need to add all files from jfxAppOutputDir to application resources because in this case I can copy my LICENSE file to jfxAppOutputDir and it will be found during building native packages process.

@shemnon Could you please verify this PR and deploy new version of plugin because without it impossible to add license files to native packages?

P.S.
  I have tested these changes in my project. All works fine.

P.P.S.
  As I understand it fix #55 too.