### PR TITLE
added template support for web mojo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
                 <github>boliang-micropole</github>
             </properties>
         </contributor>
+        <contributor>
+        		<name>Francesco Kriegel</name>
+        		<properties>
+        				<github>francesco-kriegel</github>
+        		</properties>
+        </contributor>
     </contributors>
 
     <scm>

--- a/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
@@ -224,7 +224,7 @@ public class GenerateKeyStoreMojo extends AbstractMojo {
                 plugin(
                         groupId("org.codehaus.mojo"),
                         artifactId("keytool-maven-plugin"),
-                        version("1.2")
+                        version("1.5")
                 ),
                 goal("generateKeyPair"),
                 configuration(

--- a/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
@@ -15,113 +15,139 @@
  */
 package com.zenjava.javafx.maven.plugin;
 
-import com.sun.javafx.tools.packager.CreateJarParams;
-import com.sun.javafx.tools.packager.PackagerException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
+import com.sun.javafx.tools.packager.CreateJarParams;
+import com.sun.javafx.tools.packager.PackagerException;
 
 /**
- * <p>Builds an executable JAR for the project that has all the trappings needed to run as a JavaFX app. This will
- * include Pre-Launchers and all the other weird and wonderful things that the JavaFX packaging tools allow and/or
- * require.</p>
+ * <p>
+ * Builds an executable JAR for the project that has all the trappings needed to run as a JavaFX app. This will include
+ * Pre-Launchers and all the other weird and wonderful things that the JavaFX packaging tools allow and/or require.
+ * </p>
  *
- * <p>Any runtime dependencies for this project will be included in a separate 'lib' sub-directory alongside the
- * resulting JavaFX friendly JAR. The manifest within the JAR will have a reference to these libraries using the
- * relative 'lib' path so that you can copy the JAR and the lib directory exactly as is and distribute this bundle.</p>
+ * <p>
+ * Any runtime dependencies for this project will be included in a separate 'lib' sub-directory alongside the resulting
+ * JavaFX friendly JAR. The manifest within the JAR will have a reference to these libraries using the relative 'lib'
+ * path so that you can copy the JAR and the lib directory exactly as is and distribute this bundle.
+ * </p>
  *
- * <p>The JAR and the 'lib' directory built by this Mojo are used as the inputs to the other distribution bundles. The
+ * <p>
+ * The JAR and the 'lib' directory built by this Mojo are used as the inputs to the other distribution bundles. The
  * native and web Mojos for example, will trigger this Mojo first and then will copy the resulting JAR into their own
- * distribution bundles.</p>
+ * distribution bundles.
+ * </p>
  *
  * @goal jar
- * @phase package
- * @execute phase="package"
  * @requiresDependencyResolution
  */
 public class JarMojo extends AbstractJfxToolsMojo {
 
-    /**
-     * Flag to switch on and off the compiling of CSS files to the binary format. In theory this has some minor
-     * performance gains, but it's debatable whether you will notice them, and some people have experienced problems
-     * with the resulting compiled files. Use at your own risk. By default this is false and CSS files are left in their
-     * plain text format as they are found.
-     *
-     * @parameter default-value=false
-     */
-    protected boolean css2bin;
+  /**
+   * Flag to switch on and off the compiling of CSS files to the binary format. In theory this has some minor
+   * performance gains, but it's debatable whether you will notice them, and some people have experienced problems with
+   * the resulting compiled files. Use at your own risk. By default this is false and CSS files are left in their plain
+   * text format as they are found.
+   *
+   * @parameter default-value=false
+   */
+  protected boolean css2bin;
 
-    /**
-     * A custom class that can act as a Pre-Loader for your app. The Pre-Loader is run before anything else and is
-     * useful for showing splash screens or similar 'progress' style windows. For more information on Pre-Loaders, see
-     * the official JavaFX packaging documentation.
-     *
-     * @parameter
-     */
-    protected String preLoader;
+  /**
+   * A custom class that can act as a Pre-Loader for your app. The Pre-Loader is run before anything else and is useful
+   * for showing splash screens or similar 'progress' style windows. For more information on Pre-Loaders, see the
+   * official JavaFX packaging documentation.
+   *
+   * @parameter
+   */
+  protected String  preLoader;
 
-    /**
-     * Flag to switch on updating the existing jar created with maven. The jar to be updated is taken from 
-     * '${project.basedir}/target/${project.build.finalName}.jar'.
-     *
-     * @parameter default-value=false
-     */
-    protected boolean updateExistingJar;
+//  /**
+//   * Flag to switch on updating the existing jar created with maven. The jar to be updated is taken from
+//   * '${project.basedir}/target/${project.build.finalName}.jar'.
+//   *
+//   * @parameter default-value=false
+//   */
+//  protected boolean updateExistingJar;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+  /**
+   * Flag to enable the creation of a lib directory, that contains all dependency jars.
+   * If the existingJar parameter is not set, then this parameter has no effect and a lib directory will be created.
+   *
+   * @parameter default-value=true
+   */
+  protected boolean createLibDir;
 
-        getLog().info("Building JavaFX JAR for application");
+  /**
+   * The filename of an existing JAR file to be used for building the JavaFX-specific bundles.
+   * If you e.g. run the maven-assembly-plugin:single goal to build a jar-with-dependencies,
+   * then you can specify the corresponding JAR filename here.
+   * If this parameter is not set, then the createLibDir parameter has no effect and a lib directory will be created.
+   *
+   * @parameter
+   */
+  protected String  existingJar;
 
-        Build build = project.getBuild();
+  public void execute() throws MojoExecutionException, MojoFailureException {
 
-        CreateJarParams createJarParams = new CreateJarParams();
-        createJarParams.setOutdir(jfxAppOutputDir);
-        createJarParams.setOutfile(jfxMainAppJarName);
-        createJarParams.setApplicationClass(mainClass);
-        createJarParams.setCss2bin(css2bin);
-        createJarParams.setPreloader(preLoader);
-        StringBuilder classpath = new StringBuilder();
-        File libDir = new File(jfxAppOutputDir, "lib");
-        if (!libDir.exists() && !libDir.mkdirs()) {
-            throw new MojoExecutionException("Unable to create app lib dir: " + libDir);
-        }
+    getLog().info("Building JavaFX JAR for application");
 
-        if (updateExistingJar) {
-            createJarParams.addResource(null, new File(build.getDirectory() + File.separator + build.getFinalName() + ".jar"));
-        } else {
-            createJarParams.addResource(new File(build.getOutputDirectory()), "");
-        }
+    Build build = project.getBuild();
 
-        try {
-            for (Object object : project.getRuntimeClasspathElements()) {
-                String path = (String) object;
-                File file = new File(path);
-                if (file.isFile()) {
-                    getLog().debug("Including classpath element: " + path);
-                    File dest = new File(libDir, file.getName());
-                    if (!dest.exists()) {
-                        Files.copy(file.toPath(), dest.toPath());
-                    }
-                    classpath.append("lib/").append(file.getName()).append(" ");
-                }
-            }
-        } catch (DependencyResolutionRequiredException e) {
-            throw new MojoExecutionException("Error resolving application classpath to use for application", e);
-        } catch (IOException e) {
-            throw new MojoExecutionException("Error copying dependency for application", e);
-        }
-        createJarParams.setClasspath(classpath.toString());
+    CreateJarParams createJarParams = new CreateJarParams();
+    createJarParams.setOutdir(jfxAppOutputDir);
+    createJarParams.setOutfile(jfxMainAppJarName);
+    createJarParams.setApplicationClass(mainClass);
+    createJarParams.setCss2bin(css2bin);
+    createJarParams.setPreloader(preLoader);
+    StringBuilder classpath = new StringBuilder();
 
-        try {
-            getPackagerLib().packageAsJar(createJarParams);
-        } catch (PackagerException e) {
-            throw new MojoExecutionException("Unable to build JFX JAR for application", e);
-        }
+    if (existingJar != null) {
+//          createJarParams.addResource(null, new File(build.getDirectory() + File.separator + build.getFinalName() + ".jar"));
+      createJarParams.addResource(new File(build.getDirectory()), existingJar);
+    } else {
+          createJarParams.addResource(new File(build.getOutputDirectory()), "");
     }
+
+    if (createLibDir || existingJar == null) {
+      File libDir = new File(jfxAppOutputDir, "lib");
+      if (!libDir.exists() && !libDir.mkdirs()) {
+        throw new MojoExecutionException("Unable to create app lib dir: " + libDir);
+      }
+      try {
+        for (Object object : project.getRuntimeClasspathElements()) {
+          String path = (String) object;
+          File file = new File(path);
+          if (file.isFile()) {
+            getLog().debug("Including classpath element: " + path);
+            File dest = new File(libDir, file.getName());
+            if (!dest.exists()) {
+              Files.copy(file.toPath(), dest.toPath());
+            }
+            classpath.append("lib/").append(file.getName()).append(" ");
+          }
+        }
+      } catch (DependencyResolutionRequiredException e) {
+        throw new MojoExecutionException("Error resolving application classpath to use for application", e);
+      } catch (IOException e) {
+        throw new MojoExecutionException("Error copying dependency for application", e);
+      }
+    }
+    createJarParams.setClasspath(classpath.toString());
+
+    try {
+      getPackagerLib().packageAsJar(createJarParams);
+    } catch (PackagerException e) {
+      throw new MojoExecutionException("Unable to build JFX JAR for application", e);
+    }
+  }
 }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -47,8 +47,6 @@ import java.util.Set;
  * on the JavaFX packaging tools.</p>
  *
  * @goal native
- * @phase package
- * @execute goal="jar"
  */
 public class NativeMojo extends AbstractJfxToolsMojo {
 
@@ -178,7 +176,7 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     protected Map<String, String> bundleArguments;
 
     /**
-     * The name of the JavaFX packaged executable to be built into the 'native/bundles' directory. By default this will
+     * The name of the JavaFX packaged executable to be built into the 'native' directory. By default this will
      * be the finalName as set in your project. Change this if you want something nicer.
      *
      * @parameter default-value="${project.build.finalName}"

--- a/src/main/java/com/zenjava/javafx/maven/plugin/WebMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/WebMojo.java
@@ -19,12 +19,14 @@ import com.sun.javafx.tools.packager.DeployParams;
 import com.sun.javafx.tools.packager.PackagerException;
 import com.sun.javafx.tools.packager.SignJarParams;
 import com.sun.javafx.tools.packager.bundlers.Bundler;
+
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * <p>Generates web deployment bundles (applet and webstart). This Mojo simply wraps the JavaFX packaging tools
@@ -163,6 +165,11 @@ public class WebMojo extends AbstractJfxToolsMojo {
      */
     protected String keyStoreType;
 
+    /**
+     * @parameter
+     */
+    protected List<String> templates;
+
 
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -198,6 +205,16 @@ public class WebMojo extends AbstractJfxToolsMojo {
             String embeddedWidth = this.embeddedWidth != null ? this.embeddedWidth : String.valueOf(width);
             String embeddedHeight = this.embeddedHeight != null ? this.embeddedHeight : String.valueOf(height);
             deployParams.setEmbeddedDimensions(embeddedWidth, embeddedHeight);
+            
+            if (templates != null)
+                for (String template : templates) {
+                  final File in = new File(project.getBasedir(), "src/main/deploy/templates/" + template);
+                  final File out = new File(webOutputDir, template);
+                  getLog().info("Using template: " + in);
+                  deployParams.addTemplate(in, out);
+                }
+              else
+                getLog().info("Using default template.");
 
             // turn off native bundles for this web build
             //noinspection deprecation


### PR DESCRIPTION
The current version does not support user-defined templates for HTML files when creating a WebStart bundle. This branch supports this feature.

## Usage
###### 1. Add HTML templates to `src/main/deploy/templates`.

A sample template for embedded launch:
```
<html>
	<head>
		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
		<title>Your JavaFX Application</title>
		#DT.SCRIPT.CODE#
		#DT.EMBED.CODE.ONLOAD#
		<style>
			html, body, #javafx-app-placeholder, #fxApp {
				margin: 0;
				overflow: hidden;
				padding: 0;
				width: 100%;
				height: 100%;
			}
		</style>
	</head>
	<body>
		<div id='javafx-app-placeholder'></div>
	</body>
</html>
```
A sample template for windowed launch:
```
<html>
	<head>
		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
		<title>Your JavaFX Application</title>
		#DT.SCRIPT.CODE#
	</head>
	<body>
		<!-- 		<a href='index.html' onclick="return #DT.LAUNCH.CODE#">Launch Your JavaFX Application in its own window</a> -->
		<script>
			#DT.LAUNCH.CODE#
			function reload() {
				window.location.href = "index.html";
			}
			window.setTimeout(reload, 6000);
		</script>
	</body>
</html>
```
###### 2. Reference them in the plugin configuration as follows:
```
<plugin>
	<groupId>com.zenjava</groupId>
	<artifactId>javafx-maven-plugin</artifactId>
	<version>8.1.3-SNAPSHOT</version>
	<configuration>
		<templates>
			<template>template1.html</template>
			<template>template2.html</template>
		</templates>
	<configuration>
</plugin>
```
###### 3. Run `mvn jfx:web` or add the web mojo to your build lifecycle.