### PR TITLE
Fix maven lifecycle-usage

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Daniel Zwolenski.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.zenjava.javafx.maven.plugin;
 
 import com.oracle.tools.packager.Log;

--- a/src/main/java/com/zenjava/javafx/maven/plugin/CliJarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/CliJarMojo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 Daniel Zwolenski.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zenjava.javafx.maven.plugin;
+
+/**
+ * <p>Builds an executable JAR for the project that has all the trappings needed to run as a JavaFX app. This will
+ * include Pre-Launchers and all the other weird and wonderful things that the JavaFX packaging tools allow and/or
+ * require.</p>
+ *
+ * <p>Any runtime dependencies for this project will be included in a separate 'lib' sub-directory alongside the
+ * resulting JavaFX friendly JAR. The manifest within the JAR will have a reference to these libraries using the
+ * relative 'lib' path so that you can copy the JAR and the lib directory exactly as is and distribute this bundle.</p>
+ *
+ * <p>The JAR and the 'lib' directory built by this Mojo are used as the inputs to the other distribution bundles. The
+ * native and web Mojos for example, will trigger this Mojo first and then will copy the resulting JAR into their own
+ * distribution bundles.</p>
+ * 
+ * @goal jar
+ * @execute lifecycle="jfxjar" phase="package"
+ * @requiresDependencyResolution
+ */
+public class CliJarMojo extends JarMojo {
+    // NO-OP
+}

--- a/src/main/java/com/zenjava/javafx/maven/plugin/CliNativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/CliNativeMojo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 Daniel Zwolenski.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zenjava.javafx.maven.plugin;
+
+/**
+ * <p>Generates native deployment bundles (MSI, EXE, DMG, RPG, etc). This Mojo simply wraps the JavaFX packaging tools
+ * so it has all the problems and limitations of those tools. Most importantly, this will only generate a native bundle
+ * for the platform you are building on (e.g. if you're on Windows you will get an MSI and an EXE). Additionally you
+ * need to first download and install the 3rd-party tools that the JavaFX packaging tools require (e.g. Wix, Inno,
+ * etc).</p>
+ *
+ * <p>For detailed information on generating native packages it is best to first read through the official documentation
+ * on the JavaFX packaging tools.</p>
+ * 
+ * @goal native
+ * @execute goal="jar"
+ */
+public class CliNativeMojo extends NativeMojo {
+    // NO-OP
+}

--- a/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
@@ -28,21 +28,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 /**
- * <p>Builds an executable JAR for the project that has all the trappings needed to run as a JavaFX app. This will
- * include Pre-Launchers and all the other weird and wonderful things that the JavaFX packaging tools allow and/or
- * require.</p>
- *
- * <p>Any runtime dependencies for this project will be included in a separate 'lib' sub-directory alongside the
- * resulting JavaFX friendly JAR. The manifest within the JAR will have a reference to these libraries using the
- * relative 'lib' path so that you can copy the JAR and the lib directory exactly as is and distribute this bundle.</p>
- *
- * <p>The JAR and the 'lib' directory built by this Mojo are used as the inputs to the other distribution bundles. The
- * native and web Mojos for example, will trigger this Mojo first and then will copy the resulting JAR into their own
- * distribution bundles.</p>
- *
- * @goal jar
+ * @goal build-jar
  * @phase package
- * @execute phase="package"
  * @requiresDependencyResolution
  */
 public class JarMojo extends AbstractJfxToolsMojo {
@@ -73,8 +60,20 @@ public class JarMojo extends AbstractJfxToolsMojo {
      * @parameter default-value=false
      */
     protected boolean updateExistingJar;
+    
+    /**
+     * Will be set when having goal "build-jar" within package-phase and calling "jfx:jar" or "jfx:native" from CLI. Internal usage only.
+     * 
+     * @parameter default-value=false
+     */
+    protected boolean jfxCallFromCLI;
 
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if( jfxCallFromCLI ){
+            getLog().info("call from CLI - skipping creation of JavaFX JAR for application");
+            return;
+        }
 
         getLog().info("Building JavaFX JAR for application");
 

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -21,7 +21,6 @@ import com.oracle.tools.packager.ConfigException;
 import com.oracle.tools.packager.RelativeFileSet;
 import com.oracle.tools.packager.StandardBundlerParam;
 import com.oracle.tools.packager.UnsupportedPlatformException;
-import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
@@ -37,18 +36,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * <p>Generates native deployment bundles (MSI, EXE, DMG, RPG, etc). This Mojo simply wraps the JavaFX packaging tools
- * so it has all the problems and limitations of those tools. Most importantly, this will only generate a native bundle
- * for the platform you are building on (e.g. if you're on Windows you will get an MSI and an EXE). Additionally you
- * need to first download and install the 3rd-party tools that the JavaFX packaging tools require (e.g. Wix, Inno,
- * etc).</p>
- *
- * <p>For detailed information on generating native packages it is best to first read through the official documentation
- * on the JavaFX packaging tools.</p>
- *
- * @goal native
- * @phase package
- * @execute goal="jar"
+ * @goal build-native
  */
 public class NativeMojo extends AbstractJfxToolsMojo {
 
@@ -174,16 +162,6 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     protected boolean needMenu;
 
     /**
-     * A custom class that can act as a Pre-Loader for your app. The Pre-Loader is run before anything else and is
-     * useful for showing splash screens or similar 'progress' style windows. For more information on Pre-Loaders, see
-     * the official JavaFX packaging documentation.
-     *
-     * @parameter
-     * @deprecated
-     */
-    protected String preLoader;
-
-    /**
      * A list of bundler arguments.  The particular keys and the meaning of their values are dependent on the bundler
      * that is reading the arguments.  Any argument not recognized by a bundler is silently ignored, so that arguments
      * that are specific to a specific bundler (for example, a Mac OS X Code signing key name) can be configured and
@@ -202,19 +180,29 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      * @parameter default-value="${project.build.finalName}"
      */
     protected String appName;
+    
+    /**
+     * Will be set when having goal "build-native" within package-phase and calling "jfx:native" from CLI. Internal usage only.
+     * 
+     * @parameter default-value=false
+     */
+    protected boolean jfxCallFromCLI;
 
-
-
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if( jfxCallFromCLI ){
+            getLog().info("call from CLI - skipping creation of Native Installers");
+            return;
+        }
 
         //noinspection deprecation
-        if ("NONE".equals(bundleType)) return;
+        if( "NONE".equalsIgnoreCase(bundleType) ){
+            return;
+        }
 
         getLog().info("Building Native Installers");
 
         try {
-            Build build = project.getBuild();
-
             Map<String, ? super Object> params = new HashMap<>();
 
 

--- a/src/main/java/com/zenjava/javafx/maven/plugin/RunMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/RunMojo.java
@@ -27,10 +27,9 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 /**
  * A convenience class for running the JavaFX application defined by the POM. This is really just a wrapper around the
  * standard Maven exec command, however it pulls the mainClass from the JavaFX plugin configuration so you don't have to
- * respecify it.
+ * respecify it. This does not trigger the configured preloader, because we bypass it by calling main directly.
  *
  * @goal run
- * @phase package
  * @execute phase="compile"
  * @requiresDependencyResolution
  */
@@ -78,7 +77,7 @@ public class RunMojo extends AbstractMojo {
                 plugin(
                         groupId("org.codehaus.mojo"),
                         artifactId("exec-maven-plugin"),
-                        version("1.2.1")
+                        version("1.4.0")
                 ),
                 goal("java"),
                 configuration(

--- a/src/main/java/com/zenjava/javafx/maven/plugin/WebMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/WebMojo.java
@@ -45,9 +45,7 @@ import java.io.File;
  * on the JavaFX packaging tools.</p>
  *
  * @goal web
- * @phase package
- * @execute goal="jar"
- */
+ * @execute lifecycle="jfxjar" phase="package" */
 public class WebMojo extends AbstractJfxToolsMojo {
 
     /**

--- a/src/main/resources/META-INF/maven/lifecycle.xml
+++ b/src/main/resources/META-INF/maven/lifecycle.xml
@@ -1,0 +1,21 @@
+<lifecycles xmlns="http://maven.apache.org/LIFECYCLE/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/LIFECYCLE/1.0.0 http://maven.apache.org/xsd/lifecycle-1.0.0.xsd">
+    <lifecycle>
+        <id>jfxjar</id>
+        <phases>
+            <phase>
+                <id>package</id>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jfxCallFromCLI>true</jfxCallFromCLI>
+                </configuration>
+            </phase>
+        </phases>
+    </lifecycle>
+</lifecycles>


### PR DESCRIPTION
Before this changes, calling "jfx:jar"/"jfx:native" via CLI was mixing lifecycle and direct-call.
Now its possible to have this kind of configuration:
```xml
<plugin>
    <groupId>com.zenjava</groupId>
    <artifactId>javafx-maven-plugin</artifactId>
    <version>8.1.3-SNAPSHOT</version>
    <configuration>
        <updateExistingJar>true</updateExistingJar>

        <mainClass>javafx_and_proguard.MainApp</mainClass>
    </configuration>
    <executions>
        <execution>
            <id>create-jfxjar</id>
            <phase>package</phase>
            <goals>
                <goal>build-jar</goal>
            </goals>
        </execution>
        <execution>
            <id>create-native-mac</id>
            <phase>package</phase>
            <goals>
                <goal>build-native</goal>
            </goals>
            <configuration>
                <keyStoreAlias>example-user</keyStoreAlias>
                <keyStorePassword>example-password</keyStorePassword>
                <allPermissions>true</allPermissions>

                <bundler>mac.app</bundler>
            </configuration>
        </execution>
    </executions>
</plugin>
```

This allows to have encryption/obfruscation/etc. and javafx-maven-plugin within regular "mvn install" call.

Now this is possible to create javafx-jar/installer:
* ```mvn install``` (with configured phases)
* ```mvn jfx:jar```
* ```mvn jfx:native```

When having both mixed, configured executions are skipped.

(to mention it: Fixed license-header and removed deprecated preloader-field of native-mojo)