### PR TITLE
workaround for #124

### DIFF
--- a/src/it/14-native-launcher-linux-workaround124/invoker.properties
+++ b/src/it/14-native-launcher-linux-workaround124/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean package
+invoker.java.version = 1.8.0.40+
+invoker.os.family = !windows, unix, !mac

--- a/src/it/14-native-launcher-linux-workaround124/pom.xml
+++ b/src/it/14-native-launcher-linux-workaround124/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-14-native-launcher-linux-workaround124</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <!-- don't add JRE to native distribution bundle (reduces build-time, but has some risks (see documentation for this) -->
+                    <runtime />
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-jfxjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-native</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/14-native-launcher-linux-workaround124/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/14-native-launcher-linux-workaround124/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/14-native-launcher-linux-workaround124/verify.bsh
+++ b/src/it/14-native-launcher-linux-workaround124/verify.bsh
@@ -1,0 +1,22 @@
+import java.io.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeAppFolder = new File( jfxFolder, "native" );
+if( !jfxNativeAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// ugly, but works
+File configurationFile = new File( basedir, "target/jfx/native/javafx-maven-plugin-test-14-native-launcher-linux-workaround124-1.0/app/javafx-maven-plugin-test-14-native-launcher-linux-workaround124-1.cfg" );
+if( !configurationFile.exists() ){
+    throw new Exception( "workaround din't work here!");
+}

--- a/src/it/15-native-launcher-linux-workaround124-skipped/invoker.properties
+++ b/src/it/15-native-launcher-linux-workaround124-skipped/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean package
+invoker.java.version = 1.8.0.40+
+invoker.os.family = !windows, unix, !mac

--- a/src/it/15-native-launcher-linux-workaround124-skipped/pom.xml
+++ b/src/it/15-native-launcher-linux-workaround124-skipped/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-15-native-launcher-linux-workaround124-skipped</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <!-- don't add JRE to native distribution bundle (reduces build-time, but has some risks (see documentation for this) -->
+                    <runtime />
+                    <skipNativeLauncherWorkaround124>true</skipNativeLauncherWorkaround124>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-jfxjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-native</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/15-native-launcher-linux-workaround124-skipped/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/15-native-launcher-linux-workaround124-skipped/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/15-native-launcher-linux-workaround124-skipped/verify.bsh
+++ b/src/it/15-native-launcher-linux-workaround124-skipped/verify.bsh
@@ -1,0 +1,26 @@
+import java.io.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeAppFolder = new File( jfxFolder, "native" );
+if( !jfxNativeAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// ugly, but works
+File workedAroundConfigurationFile = new File( basedir, "target/jfx/native/javafx-maven-plugin-test-15-native-launcher-linux-workaround124-skipped-1.0/app/javafx-maven-plugin-test-15-native-launcher-linux-workaround124-skipped-1.cfg" );
+if( workedAroundConfigurationFile.exists() ){
+    throw new Exception( "workaround shouldn't work here!");
+}
+File configurationFile = new File( basedir, "target/jfx/native/javafx-maven-plugin-test-15-native-launcher-linux-workaround124-skipped-1.0/app/javafx-maven-plugin-test-15-native-launcher-linux-workaround124-skipped-1.0.cfg" );
+if( !configurationFile.exists() ){
+    throw new Exception( "configfile should exist");
+}

--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
@@ -127,4 +127,18 @@ public abstract class AbstractJfxToolsMojo extends AbstractMojo {
         }
         return this.packagerLib;
     }
+
+    protected boolean isJavaVersion(int oracleJavaVersion) {
+        String javaVersion = System.getProperty("java.version");
+        return javaVersion.startsWith("1." + oracleJavaVersion);
+    }
+
+    protected boolean isAtLeastOracleJavaUpdateVersion(int updateNumber) {
+        String javaVersion = System.getProperty("java.version");
+        String[] javaVersionSplitted = javaVersion.split("_");
+        if( javaVersionSplitted.length <= 1 ) {
+            return false;
+        }
+        return Integer.parseInt(javaVersionSplitted[1], 10) >= updateNumber;
+    }
 }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
@@ -201,11 +201,9 @@ public class JarMojo extends AbstractJfxToolsMojo {
     }
 
     private boolean checkIfJavaIsHavingPackagerJar() {
-        String javaVersion = System.getProperty("java.version");
-        boolean isJava8 = javaVersion.startsWith("1.8");
-        boolean isJava9 = javaVersion.startsWith("1.9");
-        String[] javaVersionSplitted = javaVersion.split("_");
-        if( isJava8 && javaVersionSplitted.length > 1 && Integer.parseInt(javaVersionSplitted[1], 10) >= 40 ){
+        boolean isJava8 = isJavaVersion(8);
+        boolean isJava9 = isJavaVersion(9);
+        if( isJava8 && isAtLeastOracleJavaUpdateVersion(40) ){
             return true;
         }
         if( isJava9 ){ // NOSONAR

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -202,6 +202,28 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      * @parameter
      */
     protected File additionalAppResources;
+    
+    /**
+     * Since Java version 1.8.0 Update 40 the native launcher for linux was changed and includes a bug
+     * while searching for the generated configfile. This results in wrong ouput like this:
+     * <pre>
+     * client-1.1 No main class specified
+     * client-1.1 Failed to launch JVM
+     * </pre>
+     *
+     * Scenario (which would work on windows):
+     * <ul>
+     * <li>generated launcher: i-am.working.1.2.0-SNAPSHOT</li>
+     * <li>launcher-algorithm extracts the "extension" (a concept not known in linux-space for executables) and now searches for i-am.working.1.2.cfg</li>
+     * </ul>
+     *
+     * Change this to "true" when you don't want this workaround.
+     *
+     * @see https://github.com/javafx-maven-plugin/javafx-maven-plugin/issues/124
+     *
+     * @parameter default-value=false
+     */
+    protected boolean skipNativeLauncherWorkaround124;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -210,7 +232,6 @@ public class NativeMojo extends AbstractJfxToolsMojo {
             return;
         }
 
-        //noinspection deprecation
         if( "NONE".equalsIgnoreCase(bundleType) ){
             return;
         }
@@ -219,7 +240,6 @@ public class NativeMojo extends AbstractJfxToolsMojo {
 
         try {
             Map<String, ? super Object> params = new HashMap<>();
-
 
             params.put(StandardBundlerParam.VERBOSE.getID(), verbose);
 
@@ -350,22 +370,24 @@ public class NativeMojo extends AbstractJfxToolsMojo {
                             if( "linux.app".equals(b.getID()) ){
                                 // check appName containing any dots
                                 boolean needsWorkaround = appName.contains(".");
-                                if( needsWorkaround ){
+                                if( !skipNativeLauncherWorkaround124 && needsWorkaround ){
                                     getLog().info("Applying workaround for oracle-jdk-bug since 1.8.0u40");
                                     // rename .cfg-file (makes it able to create running applications again, even within installer)
                                     String newConfigFileName = appName.substring(0, appName.lastIndexOf("."));
                                     Path oldConfigFile = nativeOutputDir.toPath().resolve(appName).resolve("app").resolve(appName + ".cfg");
                                     try{
                                         Files.move(oldConfigFile, nativeOutputDir.toPath().resolve(appName).resolve("app").resolve(newConfigFileName + ".cfg"), StandardCopyOption.ATOMIC_MOVE);
-                                    } catch(IOException ex){ // NOSONAR
-                                        getLog().warn(String.format("Couldn't rename configfile. Please see issue #124 of the javafx-maven-plugin for further details."));
+                                    } catch(IOException ex){
+                                        getLog().warn("Couldn't rename configfile. Please see issue #124 of the javafx-maven-plugin for further details.", ex);
                                     }
+                                }else{
+                                    getLog().info("Skipped workaround for native linux launcher.");
                                 }
                             }
                         }
                     }
                 } catch (UnsupportedPlatformException e) {
-                    // quietly ignore
+                    // quietly ignored
                 } catch (ConfigException e) {
                     getLog().info("Skipping " + b.getName() + " because of configuration error " + e.getMessage() + "\nAdvice to Fix: " + e.getAdvice());
                 }


### PR DESCRIPTION
* renames the `.cfg`-file for Java 8 Update 40 and following
* reworked version-check a bit

While working on issue #124, I found a bug within native linux launcher of the Oracle JDK, see issue for further details.