### PR TITLE
Tell git to ignore Eclipse metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+/.classpath
+/.project
+/.settings/
 /target/


### PR DESCRIPTION
After importing the project into Eclipse using File > Import > Existing Maven Project, the working copy appears dirty to git due to the creation of Eclipse's metadata files and folders:

* `.project`
* `.classpath`
* `.settings/`

This change tells git to ignore those files.