### PR TITLE
added workaround for generated cfg-file by using prop-file-format

### DIFF
--- a/src/it/19-native-launcher-configuration-windows-workaround167/invoker.properties
+++ b/src/it/19-native-launcher-configuration-windows-workaround167/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean package
+invoker.java.version = 1.8.0.60+
+invoker.os.family = windows, !unix, !mac

--- a/src/it/19-native-launcher-configuration-windows-workaround167/pom.xml
+++ b/src/it/19-native-launcher-configuration-windows-workaround167/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-19-native-launcher-configuration-windows-workaround167</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <appName>SimpleApp</appName>
+                    <!-- don't bundle JRE (will be problematic on windows since 1.8.0u60) -->
+                    <bundleArguments>
+                        <runtime />
+                    </bundleArguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-jfxjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-native</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/19-native-launcher-configuration-windows-workaround167/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/19-native-launcher-configuration-windows-workaround167/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/19-native-launcher-configuration-windows-workaround167/verify.bsh
+++ b/src/it/19-native-launcher-configuration-windows-workaround167/verify.bsh
@@ -1,0 +1,31 @@
+import java.io.*;
+import java.util.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeAppFolder = new File( jfxFolder, "native" );
+if( !jfxNativeAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// ugly, but works
+File configurationFile = new File( basedir, "target/jfx/native/SimpleApp/app/SimpleApp.cfg" );
+if( !configurationFile.exists() ){
+    throw new Exception( "configuration-file wasn't written?!");
+}
+
+// check for property-file-format
+List allLines = java.nio.file.Files.readAllLines(configurationFile.toPath());
+for(String singleLine: allLines){
+    if(((String) singleLine).contains("app.runtime=$APPDIR\\runtime")){
+        throw new Exception( "workaround wasn't successful");
+    }
+}

--- a/src/it/20-native-launcher-configuration-windows-workaround167-skipped/invoker.properties
+++ b/src/it/20-native-launcher-configuration-windows-workaround167-skipped/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean package
+invoker.java.version = 1.8.0.60+
+invoker.os.family = windows, !unix, !mac

--- a/src/it/20-native-launcher-configuration-windows-workaround167-skipped/pom.xml
+++ b/src/it/20-native-launcher-configuration-windows-workaround167-skipped/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-20-native-launcher-configuration-windows-workaround167-skipped</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <appName>SimpleApp</appName>
+                    <!-- don't bundle JRE (will be problematic on windows since 1.8.0u60) -->
+                    <bundleArguments>
+                        <runtime />
+                    </bundleArguments>
+                    <skipNativeLauncherWorkaround167>true</skipNativeLauncherWorkaround167>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-jfxjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-native</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/20-native-launcher-configuration-windows-workaround167-skipped/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/20-native-launcher-configuration-windows-workaround167-skipped/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/20-native-launcher-configuration-windows-workaround167-skipped/verify.bsh
+++ b/src/it/20-native-launcher-configuration-windows-workaround167-skipped/verify.bsh
@@ -1,0 +1,36 @@
+import java.io.*;
+import java.util.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeAppFolder = new File( jfxFolder, "native" );
+if( !jfxNativeAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// ugly, but works
+File configurationFile = new File( basedir, "target/jfx/native/SimpleApp/app/SimpleApp.cfg" );
+if( !configurationFile.exists() ){
+    throw new Exception( "configuration-file wasn't written?!");
+}
+
+// check for INI-file-format
+boolean appRuntimeFound = false;
+
+List allLines = java.nio.file.Files.readAllLines(configurationFile.toPath());
+for(Object singleLine: allLines){
+    if(((String) singleLine).contains("app.runtime=$APPDIR\\runtime")){
+        appRuntimeFound = true;
+    }
+}
+if(!appRuntimeFound){
+    throw new Exception( "workaround wasn't skipped");
+}


### PR DESCRIPTION
(instead of INI-file-format, because INI does not reflect our specified RUNTIME-setting)

This PR is ment to fix #167 