### PR TITLE
enforce java 8 compiler-settings

### DIFF
--- a/src/it/01-no-jfx-setup/pom.xml
+++ b/src/it/01-no-jfx-setup/pom.xml
@@ -18,5 +18,19 @@
     <organization>
         <name>ZenJava</name>
     </organization>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/it/02-cli-jfx-jar/pom.xml
+++ b/src/it/02-cli-jfx-jar/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/03-cli-jfx-native/pom.xml
+++ b/src/it/03-cli-jfx-native/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/04-cli-jfx-web/pom.xml
+++ b/src/it/04-cli-jfx-web/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/06-lifecycle-build-jfx-jar/pom.xml
+++ b/src/it/06-lifecycle-build-jfx-jar/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/07-lifecycle-build-jfx-native/pom.xml
+++ b/src/it/07-lifecycle-build-jfx-native/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/08-build-with-proguard/pom.xml
+++ b/src/it/08-build-with-proguard/pom.xml
@@ -21,6 +21,15 @@
         <finalName>javafx-and-proguard</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.github.wvengen</groupId>
                 <artifactId>proguard-maven-plugin</artifactId>
                 <version>2.0.10</version>

--- a/src/it/09-withPackagerJar/pom.xml
+++ b/src/it/09-withPackagerJar/pom.xml
@@ -33,6 +33,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/10-skip-addingPackagerJar/pom.xml
+++ b/src/it/10-skip-addingPackagerJar/pom.xml
@@ -33,6 +33,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/13-lifecycle-build-web/pom.xml
+++ b/src/it/13-lifecycle-build-web/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/14-native-launcher-linux-workaround124/pom.xml
+++ b/src/it/14-native-launcher-linux-workaround124/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/15-native-launcher-linux-workaround124-skipped/pom.xml
+++ b/src/it/15-native-launcher-linux-workaround124-skipped/pom.xml
@@ -22,6 +22,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>@project.version@</version>


### PR DESCRIPTION
I encountered problems while running `mvn clean install` on my linux vm, mostly because maven-compiler-plugin was nagging about "no annotation supported with source being 1.3" or something.