### PR TITLE
Feature list bundlers mojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ upcoming Version 8.1.6 (??-Nov-2015) **available as snapshot-version**
 * added workaround for bug #167 regarding native windows launcher configuration-file (cfg-file), bug is inside Oracle JDK since 1.8.0 Update 60 (to work around this, this plugin tries to enforce property-file-format, which does not contain the problem)
 * added new property to disable workaround `<skipNativeLauncherWorkaround167>true</skipNativeLauncherWorkaround167>`
 * added some IT-tests and updated others
-
+* added new mojo: calling `mvn jfx:list-bundlers` shows currently available bundlers with ID, name and descriptions, including their specific arguments able to be passed via `<bundleArguments>`-configuration
 
 Version 8.1.5 (24-Sep-2015)
 * added workaround for bug #124 regarding native launcher, bug is inside Oracle JDK since 1.8.0 Update 40 (thanks to Jens Deters and Stefan Helfrich for testing/reporting helping information)

--- a/src/main/java/com/zenjava/javafx/maven/plugin/ListBundlersMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/ListBundlersMojo.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012 Daniel Zwolenski.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zenjava.javafx.maven.plugin;
+
+import com.oracle.tools.packager.Bundlers;
+import com.oracle.tools.packager.ConfigException;
+import com.oracle.tools.packager.UnsupportedPlatformException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+/**
+ *
+ * @author Danny Althoff
+ * @goal list-bundlers
+ */
+public class ListBundlersMojo extends AbstractMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Bundlers bundlers = Bundlers.createBundlersInstance();
+
+        getLog().info("Available bundlers:");
+        getLog().info("-------------------");
+        Map<String, ? super Object> dummyParams = new HashMap<>();
+        bundlers.getBundlers().stream().forEach((bundler) -> {
+            try{
+                bundler.validate(dummyParams);
+            } catch(UnsupportedPlatformException ex){
+                return;
+            } catch(ConfigException ex){
+                // NO-OP
+            }
+
+            getLog().info("ID: " + bundler.getID());
+            getLog().info("Name: " + bundler.getName());
+            getLog().info("Description: " + bundler.getDescription());
+            getLog().info("");
+        });
+    }
+
+}

--- a/src/main/java/com/zenjava/javafx/maven/plugin/ListBundlersMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/ListBundlersMojo.java
@@ -15,11 +15,14 @@
  */
 package com.zenjava.javafx.maven.plugin;
 
+import com.oracle.tools.packager.BundlerParamInfo;
 import com.oracle.tools.packager.Bundlers;
 import com.oracle.tools.packager.ConfigException;
 import com.oracle.tools.packager.UnsupportedPlatformException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -50,7 +53,19 @@ public class ListBundlersMojo extends AbstractMojo {
             getLog().info("ID: " + bundler.getID());
             getLog().info("Name: " + bundler.getName());
             getLog().info("Description: " + bundler.getDescription());
-            getLog().info("");
+
+            Collection<BundlerParamInfo<?>> bundleParameters = bundler.getBundleParameters();
+            Optional.ofNullable(bundleParameters).ifPresent(nonNullBundleArguments -> {
+                getLog().info("Available bundle arguments: ");
+                nonNullBundleArguments.stream().forEach(bundleArgument -> {
+                    getLog().info("\t\tArgument ID: " + bundleArgument.getID());
+                    getLog().info("\t\tArgument Type: " + bundleArgument.getValueType().getName());
+                    getLog().info("\t\tArgument Name: " + bundleArgument.getName());
+                    getLog().info("\t\tArgument Description: " + bundleArgument.getDescription());
+                    getLog().info("");
+                });
+            });
+            getLog().info("-------------------");
         });
     }
 


### PR DESCRIPTION
Added feature to get knowledge about current used/installed bundlers. This lists their IDs, the names and some description, including the specific `<bundleArgument>`-entries.

But to be aware: our `<bundleArgument>`-implementation only allows strings (which should be okay, since strings will be automatcally converted to the real type, when possible, it's a feature provided by the class com.oracle.tools.packager.StandardBundlerParam)