### PR TITLE
Feature fileassocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ Improvements:
 ==================
 
 upcoming Version 8.2.1 (??-2015)
-* nothing yet changed
+* added possibility for adding file associations

--- a/src/it/21-create-fileassociations/invoker.properties
+++ b/src/it/21-create-fileassociations/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = clean jfx:native
+invoker.os.family = !windows, unix, !mac

--- a/src/it/21-create-fileassociations/pom.xml
+++ b/src/it/21-create-fileassociations/pom.xml
@@ -1,0 +1,74 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-21-create-fileassociations</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <version.java.source>1.8</version.java.source>
+        <version.java.target>1.8</version.java.target>
+
+        <!-- version-management -->
+        <version.maven-compiler-plugin>3.3</version.maven-compiler-plugin>
+        <!-- /version-management -->
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.maven-compiler-plugin}</version>
+                <configuration>
+                    <source>${version.java.source}</source>
+                    <target>${version.java.target}</target>
+                    <showDeprecation>true</showDeprecation>
+                    <compilerArgument>-Xlint:unchecked</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <verbose>true</verbose>
+                    <bundleArguments>
+                        <runtime />
+                    </bundleArguments>
+                    <fileAssociations>
+                        <fileAssociation>
+                            <description>association with space separated extensions</description>
+                            <extensions>ext1 ext2</extensions>
+                            <contentType>application/dummy application/dummy2</contentType>
+                            <icon>somePathToIcon</icon>
+                        </fileAssociation>
+                        <fileAssociation>
+                            <description>association with comma separated extensions and no icon</description>
+                            <extensions>ext3,ext4</extensions>
+                            <contentType>application/dummy3,application/dummy4</contentType>
+                        </fileAssociation>
+                    </fileAssociations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/21-create-fileassociations/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/21-create-fileassociations/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/21-create-fileassociations/verify.bsh
+++ b/src/it/21-create-fileassociations/verify.bsh
@@ -1,0 +1,18 @@
+import java.io.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeFolder = new File( jfxFolder, "native" );
+if( !jfxNativeFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// TODO

--- a/src/it/22-create-fileassociations-single-mimetypes/invoker.properties
+++ b/src/it/22-create-fileassociations-single-mimetypes/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean jfx:native

--- a/src/it/22-create-fileassociations-single-mimetypes/pom.xml
+++ b/src/it/22-create-fileassociations-single-mimetypes/pom.xml
@@ -1,0 +1,74 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-22-create-fileassociations-single-mimetypes</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <version.java.source>1.8</version.java.source>
+        <version.java.target>1.8</version.java.target>
+
+        <!-- version-management -->
+        <version.maven-compiler-plugin>3.3</version.maven-compiler-plugin>
+        <!-- /version-management -->
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.maven-compiler-plugin}</version>
+                <configuration>
+                    <source>${version.java.source}</source>
+                    <target>${version.java.target}</target>
+                    <showDeprecation>true</showDeprecation>
+                    <compilerArgument>-Xlint:unchecked</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <verbose>true</verbose>
+                    <bundleArguments>
+                        <runtime />
+                    </bundleArguments>
+                    <fileAssociations>
+                        <fileAssociation>
+                            <description>association 1</description>
+                            <extensions>ext1</extensions>
+                            <contentType>application/dummy</contentType>
+                            <icon>somePathToIcon</icon>
+                        </fileAssociation>
+                        <fileAssociation>
+                            <description>association 2</description>
+                            <extensions>ext2</extensions>
+                            <contentType>application/dummy2</contentType>
+                        </fileAssociation>
+                    </fileAssociations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/22-create-fileassociations-single-mimetypes/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/22-create-fileassociations-single-mimetypes/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/22-create-fileassociations-single-mimetypes/verify.bsh
+++ b/src/it/22-create-fileassociations-single-mimetypes/verify.bsh
@@ -1,0 +1,18 @@
+import java.io.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeFolder = new File( jfxFolder, "native" );
+if( !jfxNativeFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// TODO

--- a/src/main/java/com/zenjava/javafx/maven/plugin/FileAssociation.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/FileAssociation.java
@@ -12,14 +12,17 @@ public class FileAssociation {
      * @parameter
      */
     private String description = null;
+
     /**
      * @parameter
      */
     private String extensions = null;
+
     /**
      * @parameter
      */
     private String contentType = null;
+
     /**
      * @parameter
      */

--- a/src/main/java/com/zenjava/javafx/maven/plugin/FileAssociation.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/FileAssociation.java
@@ -1,0 +1,60 @@
+package com.zenjava.javafx.maven.plugin;
+
+import java.io.File;
+
+/**
+ *
+ * @author Danny Althoff
+ */
+public class FileAssociation {
+
+    /**
+     * @parameter
+     */
+    private String description = null;
+    /**
+     * @parameter
+     */
+    private String extensions = null;
+    /**
+     * @parameter
+     */
+    private String contentType = null;
+    /**
+     * @parameter
+     */
+    private File icon = null;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(String extensions) {
+        this.extensions = extensions;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public File getIcon() {
+        return icon;
+    }
+
+    public void setIcon(File icon) {
+        this.icon = icon;
+    }
+
+}

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -261,6 +261,8 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      * It is possible to create file associations when using native installers. When specified,
      * all file associations are bound to the main native launcher. There is no support for bunding
      * them to second launchers.
+     * <p>
+     * For more informatione, please see official information source: https://docs.oracle.com/javase/8/docs/technotes/guides/deploy/javafx_ant_task_reference.html#CIAIDHBJ
      *
      * @parameter
      */

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -257,6 +257,11 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      */
     protected boolean skipNativeLauncherWorkaround167;
 
+    /**
+     * @parameter
+     */
+    private List<FileAssociation> fileAssociations;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if( jfxCallFromCLI ){

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -258,6 +258,10 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     protected boolean skipNativeLauncherWorkaround167;
 
     /**
+     * It is possible to create file associations when using native installers. When specified,
+     * all file associations are bound to the main native launcher. There is no support for bunding
+     * them to second launchers.
+     *
      * @parameter
      */
     private List<FileAssociation> fileAssociations;
@@ -418,6 +422,19 @@ public class NativeMojo extends AbstractJfxToolsMojo {
             if( duplicateLauncherNamesCheckSet.size() != launcherNames.size() ){
                 throw new MojoExecutionException("Secondary launcher needs to have different name, please adjust appName inside your configuration.");
             }
+
+            Optional.ofNullable(fileAssociations).ifPresent(associations -> {
+                final List<Map<String, ? super Object>> allAssociations = new ArrayList<>();
+                associations.stream().forEach(association -> {
+                    Map<String, ? super Object> settings = new HashMap<>();
+                    settings.put(StandardBundlerParam.FA_DESCRIPTION.getID(), association.getDescription());
+                    settings.put(StandardBundlerParam.FA_ICON.getID(), association.getIcon());
+                    settings.put(StandardBundlerParam.FA_EXTENSIONS.getID(), association.getExtensions());
+                    settings.put(StandardBundlerParam.FA_CONTENT_TYPE.getID(), association.getContentType());
+                    allAssociations.add(settings);
+                });
+                params.put(StandardBundlerParam.FILE_ASSOCIATIONS.getID(), allAssociations);
+            });
 
             // bugfix for "bundler not being able to produce native bundle without JRE on windows"
             // https://github.com/javafx-maven-plugin/javafx-maven-plugin/issues/167


### PR DESCRIPTION
Added some feature which was able to use when using ANT-configuration: file associations when having native installers

Example configuration:
```xml
<configuration>
    <mainClass>com.zenjava.test.Main</mainClass>
    <verbose>true</verbose>
    <bundleArguments>
        <runtime />
    </bundleArguments>
    <fileAssociations>
        <fileAssociation>
            <description>association 1</description>
            <extensions>ext1</extensions>
            <contentType>application/dummy</contentType>
            <icon>somePathToIcon</icon>
        </fileAssociation>
        <fileAssociation>
            <description>association 2</description>
            <extensions>ext2</extensions>
            <contentType>application/dummy2</contentType>
        </fileAssociation>
    </fileAssociations>
</configuration>
```