### PR TITLE
Rework keystore generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,12 +332,6 @@
             <version>2.2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>keytool-maven-plugin</artifactId>
-            <version>1.5</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>javafx-packager</groupId>
             <artifactId>javafx-packager</artifactId>
             <version>1.8.0_20</version>

--- a/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
@@ -225,29 +225,33 @@ public class GenerateKeyStoreMojo extends AbstractMojo {
             // generated folder if it does not exist
             Files.createDirectories(keyStore.getParentFile().toPath());
 
-            ProcessBuilder pb = new ProcessBuilder().inheritIO().command(
-                    "keytool",
-                    "-genkeypair",
-                    "-keystore",
-                    keyStore.getPath(),
-                    "-alias",
-                    keyStoreAlias,
-                    "-storepass",
-                    keyStorePassword,
-                    "-keypass",
-                    keyPassword,
-                    "-dname",
-                    distinguishedName,
-                    "-sigalg",
-                    "SHA256withRSA",
-                    "-validity",
-                    "100",
-                    "-keyalg",
-                    "RSA",
-                    "-keysize",
-                    "2048",
-                    (verbose) ? "-v" : ""
-            );
+            List<String> command = new ArrayList<>();
+
+            command.add("keytool");
+            command.add("-genkeypair");
+            command.add("-keystore");
+            command.add(keyStore.getPath());
+            command.add("-alias");
+            command.add(keyStoreAlias);
+            command.add("-storepass");
+            command.add(keyStorePassword);
+            command.add("-keypass");
+            command.add(keyPassword);
+            command.add("-dname");
+            command.add(distinguishedName);
+            command.add("-sigalg");
+            command.add("SHA256withRSA");
+            command.add("-validity");
+            command.add("100");
+            command.add("-keyalg");
+            command.add("RSA");
+            command.add("-keysize");
+            command.add("2048");
+            if( verbose ){
+                command.add("-v");
+            }
+
+            ProcessBuilder pb = new ProcessBuilder().inheritIO().command(command);
             Process p = pb.start();
             p.waitFor();
         } catch(IOException | InterruptedException ex){

--- a/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
@@ -225,7 +225,7 @@ public class GenerateKeyStoreMojo extends AbstractMojo {
             // generated folder if it does not exist
             Files.createDirectories(keyStore.getParentFile().toPath());
 
-            ProcessBuilder pb = new ProcessBuilder(
+            ProcessBuilder pb = new ProcessBuilder().inheritIO().command(
                     "keytool",
                     "-genkeypair",
                     "-keystore",
@@ -248,11 +248,6 @@ public class GenerateKeyStoreMojo extends AbstractMojo {
                     "2048",
                     (verbose) ? "-v" : ""
             );
-            if( verbose ){
-                File log = File.createTempFile("javafx-maven-plugin", ".log");
-                pb.redirectErrorStream(true);
-                pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log));
-            }
             Process p = pb.start();
             p.waitFor();
         } catch(IOException | InterruptedException ex){


### PR DESCRIPTION
Use ProcessBuilder by direct calling the tool instead of using another maven-plugin (keytool-maven-plugin).