### PR TITLE
Changed the way how `mvn jfx:run` works.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.zenjava</groupId>
     <artifactId>javafx-maven-plugin</artifactId>
-    <version>8.3.1-SNAPSHOT</version>
+    <version>8.4.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -327,9 +327,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.twdata.maven</groupId>
-            <artifactId>mojo-executor</artifactId>
-            <version>2.2.0</version>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>javafx-packager</groupId>


### PR DESCRIPTION
Previously we were executing directly the specified mainClass, with the new way, the run-goal now launches another java-thread and triggers all jfx-parts including preloaders and settings like jvmSettings inside `.cfg`-file.

As a nice side-effect we can ditch another dependency (mojo-executor) and corrected our maven-plugin dependencies.