### PR TITLE
Make it possible to have custom native bundlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Set version to new SNAPSHOT-version:
 Last Release Notes
 ==================
 
-**Version 8.4.0 (11-Mar-2015)**
+**Version 8.4.0 (11-Mar-2016)**
 
 New:
 * when creating JNLP-files, your can now choose between Blob Signing (which was introduced since JavaFX but seems has never worked, and will be removed from Java 9) or normal signing done by `jarsigner` by providing the new proverty `<noBlobSigning>true</noBlobSigning>`
@@ -110,7 +110,13 @@ Improvements:
 (Not yet) Release(d) Notes
 ==========================
 
-upcoming Version 8.4.1 (???-2016)
+upcoming Version 8.5.0 (???-2016)
 
 Bugfixes:
 * updated workaround-detection for creating native bundles without JRE, because [it got fixed by latest Oracle JDK 1.8.0u92](http://www.oracle.com/technetwork/java/javase/2col/8u92-bugfixes-2949473.html)
+
+New:
+* Added ability to write and use custom bundlers! This makes it possible to customize the work which is required for your bundling-process.
+
+Improvements:
+* added IT-project "23-simple-custom-bundler"

--- a/src/it/23-simple-custom-bundler/bundler/pom.xml
+++ b/src/it/23-simple-custom-bundler/bundler/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-23-simple-custom-bundler-dummybundler</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <version.java.source>1.8</version.java.source>
+        <version.java.target>1.8</version.java.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>${version.java.source}</source>
+                    <target>${version.java.target}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+    <dependencies>
+        <dependency>
+            <groupId>javafx-packager</groupId>
+            <artifactId>javafx-packager</artifactId>
+            <version>1.8.0_20</version>
+            <scope>system</scope>
+            <systemPath>${java.home}/../lib/ant-javafx.jar</systemPath>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/23-simple-custom-bundler/bundler/src/main/java/com/zenjava/test/customBundlers/DummyBundler.java
+++ b/src/it/23-simple-custom-bundler/bundler/src/main/java/com/zenjava/test/customBundlers/DummyBundler.java
@@ -1,0 +1,55 @@
+package com.zenjava.test.customBundlers;
+
+import com.oracle.tools.packager.Bundler;
+import com.oracle.tools.packager.BundlerParamInfo;
+import com.oracle.tools.packager.ConfigException;
+import com.oracle.tools.packager.UnsupportedPlatformException;
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ *
+ * @author Danny Althoff
+ */
+public class DummyBundler implements Bundler {
+
+    @Override
+    public String getName() {
+        return "DummyBundler";
+    }
+
+    @Override
+    public String getDescription() {
+        return "DummyBundler - Example custom bundler of the javafx-maven-plugin";
+    }
+
+    @Override
+    public String getID() {
+        return "DummyBundler";
+    }
+
+    @Override
+    public String getBundleType() {
+        return "IMAGE";
+    }
+
+    @Override
+    public Collection<BundlerParamInfo<?>> getBundleParameters() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean validate(Map<String, ? super Object> map) throws UnsupportedPlatformException, ConfigException {
+        System.out.println("DummyBundler > VALIDATING");
+        return true;
+    }
+
+    @Override
+    public File execute(Map<String, ? super Object> map, File file) {
+        System.out.println("DummyBundler > EXECUTING");
+        return null;
+    }
+
+}

--- a/src/it/23-simple-custom-bundler/invoker.properties
+++ b/src/it/23-simple-custom-bundler/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean install

--- a/src/it/23-simple-custom-bundler/jfx-app/pom.xml
+++ b/src/it/23-simple-custom-bundler/jfx-app/pom.xml
@@ -1,0 +1,78 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-23-simple-custom-bundler-jfx-app</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <bundleArguments>
+                        <runtime />
+                    </bundleArguments>
+                </configuration>
+                <executions>
+                    <!-- required before build-native -->
+                    <execution>
+                        <id>create-jfxjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-native</goal>
+                        </goals>
+                        <configuration>
+                            <!-- use our new bundler -->
+                            <bundler>DummyBundler</bundler>
+                            <customBundlers>
+                                <customBundler>com.zenjava.test.customBundlers.DummyBundler</customBundler>
+                            </customBundlers>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <!-- make the javafx-maven-plugin require the custom bundler -->
+                    <dependency>
+                        <groupId>com.zenjava</groupId>
+                        <artifactId>javafx-maven-plugin-test-23-simple-custom-bundler-dummybundler</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/23-simple-custom-bundler/jfx-app/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/23-simple-custom-bundler/jfx-app/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/23-simple-custom-bundler/pom.xml
+++ b/src/it/23-simple-custom-bundler/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-23-simple-custom-bundler-parent-pom</artifactId>
+    <version>1.0</version>
+
+    <packaging>pom</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <name>Project Aggregator (Parent-POM)</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <version.java.source>1.8</version.java.source>
+        <version.java.target>1.8</version.java.target>
+    </properties>
+
+    <modules>
+        <!-- custom bundler project -->
+        <module>bundler</module>
+
+        <!-- jfx project using that custom bundler -->
+        <module>jfx-app</module>
+    </modules>
+</project>

--- a/src/it/23-simple-custom-bundler/verify.bsh
+++ b/src/it/23-simple-custom-bundler/verify.bsh
@@ -1,0 +1,12 @@
+import java.io.*;
+
+File jfxFolder = new File( basedir, "jfx-app/target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+// custom bundler does nothing but sysouts, but the normal jfx-jar should be there ;)
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}


### PR DESCRIPTION
This is required when having some custom work to be done before creating the application package. These bundlers require to implement the Bundler-interface provided by the JDK and are required to have some different bundler-id.