### PR TITLE
Workaround linux installer issue 205

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,18 @@ Improvements:
 (Not yet) Release(d) Notes
 ==========================
 
-upcoming Version 8.5.0 (???-2016)
+upcoming Version 8.5.0 (???-May-2016)
 
 Bugfixes:
 * updated workaround-detection for creating native bundles without JRE, because [it got fixed by latest Oracle JDK 1.8.0u92](http://www.oracle.com/technetwork/java/javase/2col/8u92-bugfixes-2949473.html)
+* added workaround for native linux launcher inside native linux installer bundle (DEB and RPM) not working, see issue #205 for more details on this
 
 New:
-* Added ability to write and use custom bundlers! This makes it possible to customize the work which is required for your bundling-process.
+* added ability to write and use custom bundlers! This makes it possible to customize the work which is required for your bundling-process.
+* added new property to disable "native linux launcher inside native linux installer"-fix `<skipNativeLauncherWorkaround205>true</skipNativeLauncherWorkaround205>`
 
 Improvements:
 * added IT-project "23-simple-custom-bundler"
 * added IT-project "24-simple-custom-bundler-failed", which fails to use custom bundler, but does not fail (normal behaviour)
+* added IT-projects regarding workaround for issue 205 (currenty they do nothing, I still need to write some verify-beanshell files)
+* moved workarounds and workaround-detection into its own class (makes it a bit easier to concentrate on the main work inside NativeMojo)

--- a/src/it/25-native-launcher-linux-workaround205/invoker.properties
+++ b/src/it/25-native-launcher-linux-workaround205/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean package
+invoker.java.version = 1.8.0.40+
+invoker.os.family = !windows, unix, !mac

--- a/src/it/25-native-launcher-linux-workaround205/pom.xml
+++ b/src/it/25-native-launcher-linux-workaround205/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-25-native-launcher-linux-workaround205</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <!-- don't add JRE to native distribution bundle (reduces build-time, but has some risks (see documentation for this) -->
+                    <runtime />
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-jfxjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-native</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/25-native-launcher-linux-workaround205/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/25-native-launcher-linux-workaround205/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/25-native-launcher-linux-workaround205/verify.bsh
+++ b/src/it/25-native-launcher-linux-workaround205/verify.bsh
@@ -1,0 +1,18 @@
+import java.io.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeAppFolder = new File( jfxFolder, "native" );
+if( !jfxNativeAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// TODO verify what travis-ci can build

--- a/src/it/26-native-launcher-linux-workaround205-skipped/invoker.properties
+++ b/src/it/26-native-launcher-linux-workaround205-skipped/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = clean package
+invoker.java.version = 1.8.0.40+
+invoker.os.family = !windows, unix, !mac

--- a/src/it/26-native-launcher-linux-workaround205-skipped/pom.xml
+++ b/src/it/26-native-launcher-linux-workaround205-skipped/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zenjava</groupId>
+    <artifactId>javafx-maven-plugin-test-26-native-launcher-linux-workaround205-skipped</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <developers>
+        <developer>
+            <name>Danny Althoff</name>
+            <email>fibrefox@dynamicfiles.de</email>
+            <url>https://www.dynamicfiles.de</url>
+        </developer>
+    </developers>
+
+    <organization>
+        <name>ZenJava</name>
+    </organization>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <mainClass>com.zenjava.test.Main</mainClass>
+                    <!-- don't add JRE to native distribution bundle (reduces build-time, but has some risks (see documentation for this) -->
+                    <runtime />
+                    <skipNativeLauncherWorkaround205>true</skipNativeLauncherWorkaround205>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-jfxjar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-jar</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>create-native</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build-native</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/26-native-launcher-linux-workaround205-skipped/src/main/java/com/zenjava/test/Main.java
+++ b/src/it/26-native-launcher-linux-workaround205-skipped/src/main/java/com/zenjava/test/Main.java
@@ -1,0 +1,20 @@
+package com.zenjava.test;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        primaryStage.setScene(new Scene(new Label("Hello World!")));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+}

--- a/src/it/26-native-launcher-linux-workaround205-skipped/verify.bsh
+++ b/src/it/26-native-launcher-linux-workaround205-skipped/verify.bsh
@@ -1,0 +1,18 @@
+import java.io.*;
+
+File jfxFolder = new File( basedir, "target/jfx" );
+if( !jfxFolder.exists() ){
+    throw new Exception( "there should be a jfx-folder!");
+}
+
+File jfxAppFolder = new File( jfxFolder, "app" );
+if( !jfxAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-app-folder!");
+}
+
+File jfxNativeAppFolder = new File( jfxFolder, "native" );
+if( !jfxNativeAppFolder.exists() ){
+    throw new Exception( "there should be a jfx-native-folder!");
+}
+
+// TODO verify what travis-ci can build

--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
@@ -124,21 +124,4 @@ public abstract class AbstractJfxToolsMojo extends AbstractMojo {
         }
         return this.packagerLib;
     }
-
-    protected boolean isJavaVersion(int oracleJavaVersion) {
-        String javaVersion = System.getProperty("java.version");
-        return javaVersion.startsWith("1." + oracleJavaVersion);
-    }
-
-    protected boolean isAtLeastOracleJavaUpdateVersion(int updateNumber) {
-        String javaVersion = System.getProperty("java.version");
-        String[] javaVersionSplitted = javaVersion.split("_");
-        if( javaVersionSplitted.length <= 1 ){
-            return false;
-        }
-        String javaUpdateVersionRaw = javaVersionSplitted[1];
-        // issue #159 NumberFormatException on openjdk (the reported Java version is "1.8.0_45-internal")
-        String javaUpdateVersion = javaUpdateVersionRaw.replaceAll("[^\\d]", "");
-        return Integer.parseInt(javaUpdateVersion, 10) >= updateNumber;
-    }
 }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
@@ -102,9 +102,8 @@ public abstract class AbstractJfxToolsMojo extends AbstractMojo {
     private PackagerLib packagerLib;
 
     public PackagerLib getPackagerLib() throws MojoExecutionException {
-
+        // lazy-initialization of packagerLib
         if( packagerLib == null ){
-
             // add deployDir to system classpath
             if( deployDir != null ){
                 getLog().info("Adding 'deploy' directory to Mojo classpath: " + deployDir);

--- a/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
@@ -247,9 +247,9 @@ public class JarMojo extends AbstractJfxToolsMojo {
     }
 
     private boolean checkIfJavaIsHavingPackagerJar() {
-        boolean isJava8 = isJavaVersion(8);
-        boolean isJava9 = isJavaVersion(9);
-        if( isJava8 && isAtLeastOracleJavaUpdateVersion(40) ){
+        boolean isJava8 = JavaDetectionTools.isJavaVersion(8);
+        boolean isJava9 = JavaDetectionTools.isJavaVersion(9);
+        if( isJava8 && JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(40) ){
             return true;
         }
         if( isJava9 ){ // NOSONAR

--- a/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/JarMojo.java
@@ -247,12 +247,10 @@ public class JarMojo extends AbstractJfxToolsMojo {
     }
 
     private boolean checkIfJavaIsHavingPackagerJar() {
-        boolean isJava8 = JavaDetectionTools.isJavaVersion(8);
-        boolean isJava9 = JavaDetectionTools.isJavaVersion(9);
-        if( isJava8 && JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(40) ){
+        if( JavaDetectionTools.IS_JAVA_8 && JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(40) ){
             return true;
         }
-        if( isJava9 ){ // NOSONAR
+        if( JavaDetectionTools.IS_JAVA_9 ){ // NOSONAR
             return true;
         }
         return false;

--- a/src/main/java/com/zenjava/javafx/maven/plugin/JavaDetectionTools.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/JavaDetectionTools.java
@@ -16,14 +16,23 @@
 package com.zenjava.javafx.maven.plugin;
 
 /**
- *
  * @author Danny Althoff
  */
 public class JavaDetectionTools {
 
-    public static boolean isJavaVersion(int oracleJavaVersion) {
+    public static final boolean IS_JAVA_8 = isJavaVersion(8);
+    public static final boolean IS_JAVA_9 = !IS_JAVA_8 && isJavaVersion(9) || isJavaVersion(9, true);
+
+    public static boolean isJavaVersion(int oracleJavaVersion, boolean noVersionOne) {
         String javaVersion = System.getProperty("java.version");
+        if( noVersionOne ){
+            return javaVersion.startsWith(String.valueOf(oracleJavaVersion));
+        }
         return javaVersion.startsWith("1." + oracleJavaVersion);
+    }
+
+    public static boolean isJavaVersion(int oracleJavaVersion) {
+        return isJavaVersion(oracleJavaVersion, false);
     }
 
     public static boolean isAtLeastOracleJavaUpdateVersion(int updateNumber) {

--- a/src/main/java/com/zenjava/javafx/maven/plugin/JavaDetectionTools.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/JavaDetectionTools.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012 Daniel Zwolenski.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zenjava.javafx.maven.plugin;
+
+/**
+ *
+ * @author Danny Althoff
+ */
+public class JavaDetectionTools {
+
+    public static boolean isJavaVersion(int oracleJavaVersion) {
+        String javaVersion = System.getProperty("java.version");
+        return javaVersion.startsWith("1." + oracleJavaVersion);
+    }
+
+    public static boolean isAtLeastOracleJavaUpdateVersion(int updateNumber) {
+        String javaVersion = System.getProperty("java.version");
+        String[] javaVersionSplitted = javaVersion.split("_");
+        if( javaVersionSplitted.length <= 1 ){
+            return false;
+        }
+        String javaUpdateVersionRaw = javaVersionSplitted[1];
+        // issue #159 NumberFormatException on openjdk (the reported Java version is "1.8.0_45-internal")
+        String javaUpdateVersion = javaUpdateVersionRaw.replaceAll("[^\\d]", "");
+        return Integer.parseInt(javaUpdateVersion, 10) >= updateNumber;
+    }
+}

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -632,6 +632,7 @@ public class NativeMojo extends AbstractJfxToolsMojo {
                                     workarounds.applyWorkaround124(appName, secondaryLaunchers);
                                     // only apply workaround for issue 205 when having workaround for issue 124 active
                                     if( Boolean.parseBoolean(String.valueOf(params.get(cfgWorkaround205Marker))) && !Boolean.parseBoolean((String) params.get(cfgWorkaround205DoneMarker)) ){
+                                        getLog().info("Preparing workaround for oracle-jdk-bug since 1.8.0u40 regarding native linux launcher(s) inside native linux installers.");
                                         workarounds.applyWorkaround205(appName, secondaryLaunchers, params);
                                         params.put(cfgWorkaround205DoneMarker, "true");
                                     }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -355,6 +355,11 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      */
     protected List<String> customBundlers;
 
+    /**
+     * @parameter default-value=false
+     */
+    protected boolean skipNativeLauncherWorkaround205;
+
     protected Workarounds workarounds = null;
 
     @Override
@@ -589,9 +594,13 @@ public class NativeMojo extends AbstractJfxToolsMojo {
                         if( workarounds.isWorkaroundForBug205Needed() ){
                             // check if special conditions for this are met (not jnlp, but not linux.app too, because there another workaround already works)
                             if( !"jnlp".equalsIgnoreCase(bundler) && !"linux.app".equalsIgnoreCase(bundler) && "linux.app".equalsIgnoreCase(b.getID()) ){
-                                getLog().info("Detected linux application bundler needs to run before installer bundlers are executed.");
-                                runBundler = true;
-                                params.put(cfgWorkaround205Marker, "true");
+                                if( !skipNativeLauncherWorkaround205 ){
+                                    getLog().info("Detected linux application bundler needs to run before installer bundlers are executed.");
+                                    runBundler = true;
+                                    params.put(cfgWorkaround205Marker, "true");
+                                } else {
+                                    getLog().info("Skipped workaround for native linux installer bundlers.");
+                                }
                             }
                         }
                     }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -538,7 +538,7 @@ public class NativeMojo extends AbstractJfxToolsMojo {
 
             // bugfix for "bundler not being able to produce native bundle without JRE on windows"
             // https://github.com/javafx-maven-plugin/javafx-maven-plugin/issues/167
-            if( workarounds.isWorkaround167Needed() ){
+            if( workarounds.isWorkaroundForBug167Needed() ){
                 if( !skipNativeLauncherWorkaround167 ){
                     workarounds.applyWorkaround167(params);
                 } else {
@@ -586,7 +586,7 @@ public class NativeMojo extends AbstractJfxToolsMojo {
                     // https://github.com/javafx-maven-plugin/javafx-maven-plugin/issues/205
                     // do run application bundler and put the cfg-file to application resources
                     if( System.getProperty("os.name").toLowerCase().startsWith("linux") ){
-                        if( workarounds.isWorkaround205Needed() ){
+                        if( workarounds.isWorkaroundForBug205Needed() ){
                             // check if special conditions for this are met (not jnlp, but not linux.app too, because there another workaround already works)
                             if( !"jnlp".equalsIgnoreCase(bundler) && !"linux.app".equalsIgnoreCase(bundler) && "linux.app".equalsIgnoreCase(b.getID()) ){
                                 getLog().info("Detected linux application bundler needs to run before installer bundlers are executed.");

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -356,6 +356,15 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     protected List<String> customBundlers;
 
     /**
+     * Same problem as workaround for bug 124 for native launchers, but this time regarding
+     * created native installers, where the workaround didn't apply.
+     * <p>
+     * Change this to "true" when you don't want this workaround.
+     * <p>
+     * Requires skipNativeLauncherWorkaround124 to be false.
+     *
+     * @see https://github.com/javafx-maven-plugin/javafx-maven-plugin/issues/205
+     *
      * @parameter default-value=false
      */
     protected boolean skipNativeLauncherWorkaround205;

--- a/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
@@ -62,7 +62,7 @@ public class Workarounds {
         return JavaDetectionTools.IS_JAVA_8 && JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(40) || JavaDetectionTools.IS_JAVA_9;
     }
 
-    public boolean isWorkaround167Needed() {
+    public boolean isWorkaroundForBug167Needed() {
         // this has been fixed and made available since 1.8.0u92:
         // http://www.oracle.com/technetwork/java/javase/2col/8u92-bugfixes-2949473.html
         return JavaDetectionTools.IS_JAVA_8 && JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(60) && !JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(92);
@@ -77,7 +77,7 @@ public class Workarounds {
         return params.containsKey("jnlp.allPermisions") && Boolean.parseBoolean(String.valueOf(params.get("jnlp.allPermisions")));
     }
 
-    public boolean isWorkaround205Needed() {
+    public boolean isWorkaroundForBug205Needed() {
         return (JavaDetectionTools.IS_JAVA_8 && !JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(60)) || JavaDetectionTools.IS_JAVA_9;
     }
 

--- a/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
@@ -48,7 +48,6 @@ public class Workarounds {
 
     private Log logger;
     private File nativeOutputDir;
-    private List<File> filesToDelete = new ArrayList<>();
 
     public Workarounds(File nativeOutputDir, Log logger) {
         this.logger = logger;
@@ -57,6 +56,29 @@ public class Workarounds {
 
     public Log getLog() {
         return logger;
+    }
+
+    public boolean isWorkaroundForBug124Needed() {
+        return JavaDetectionTools.IS_JAVA_8 && JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(40) || JavaDetectionTools.IS_JAVA_9;
+    }
+
+    public boolean isWorkaround167Needed() {
+        // this has been fixed and made available since 1.8.0u92:
+        // http://www.oracle.com/technetwork/java/javase/2col/8u92-bugfixes-2949473.html
+        return JavaDetectionTools.IS_JAVA_8 && JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(60) && !JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(92);
+    }
+
+    public boolean isWorkaroundForBug182Needed() {
+        // jnlp-bundler uses RelativeFileSet, and generates system-dependent dividers (\ on windows, / on others)
+        return File.separator.equals("\\");
+    }
+
+    public boolean isWorkaroundForBug185Needed(Map<String, Object> params) {
+        return params.containsKey("jnlp.allPermisions") && Boolean.parseBoolean(String.valueOf(params.get("jnlp.allPermisions")));
+    }
+
+    public boolean isWorkaround205Needed() {
+        return (JavaDetectionTools.IS_JAVA_8 && !JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(60)) || JavaDetectionTools.IS_JAVA_9;
     }
 
     protected void applyNativeLauncherWorkaround(String appName) {
@@ -266,7 +288,7 @@ public class Workarounds {
         appResourcesList.add(new RelativeFileSet(appPath.toFile(), filenameFixedConfigFiles));
 
         // special workaround when having some jdk before update 60
-        if( JavaDetectionTools.isJavaVersion(8) && !JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(60) ){
+        if( JavaDetectionTools.IS_JAVA_8 && !JavaDetectionTools.isAtLeastOracleJavaUpdateVersion(60) ){
             try{
                 // pre-update60 did not contain any list of RelativeFileSets, which requires to rework APP_RESOURCES :/
                 // TODO we need to cleanup this folder

--- a/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
@@ -234,18 +234,27 @@ public class Workarounds {
 
         // get cfg-file of main native launcher
         Path appPath = nativeOutputDir.toPath().resolve(appName).resolve("app");
-        String newConfigFileName = appName.substring(0, appName.lastIndexOf("."));
-        filenameFixedConfigFiles.add(appPath.resolve(newConfigFileName + CONFIG_FILE_EXTENSION).toFile());
+        if( appName.contains(".") ){
+            String newConfigFileName = appName.substring(0, appName.lastIndexOf("."));
+            filenameFixedConfigFiles.add(appPath.resolve(newConfigFileName + CONFIG_FILE_EXTENSION).toFile());
+        }
 
         // when having secondary native launchers, we need their cfg-files too
         Optional.ofNullable(secondaryLaunchers).ifPresent(launchers -> {
             launchers.stream().map(launcher -> {
                 return launcher.getAppName();
             }).forEach(secondaryLauncherAppName -> {
-                String newSecondaryLauncherConfigFileName = secondaryLauncherAppName.substring(0, secondaryLauncherAppName.lastIndexOf("."));
-                filenameFixedConfigFiles.add(appPath.resolve(newSecondaryLauncherConfigFileName + CONFIG_FILE_EXTENSION).toFile());
+                if( secondaryLauncherAppName.contains(".") ){
+                    String newSecondaryLauncherConfigFileName = secondaryLauncherAppName.substring(0, secondaryLauncherAppName.lastIndexOf("."));
+                    filenameFixedConfigFiles.add(appPath.resolve(newSecondaryLauncherConfigFileName + CONFIG_FILE_EXTENSION).toFile());
+                }
             });
         });
+
+        if( filenameFixedConfigFiles.isEmpty() ){
+            // it wasn't required to apply this workaround
+            return;
+        }
 
         // since 1.8.0_60 there exists some APP_RESOURCES_LIST, which contains multiple RelativeFileSet-instances
         // this is the more easy way ;)

--- a/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/Workarounds.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2012 Daniel Zwolenski.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zenjava.javafx.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ *
+ * @author Danny Althoff
+ */
+public class Workarounds {
+
+    private static final String JNLP_JAR_PATTERN = "(.*)href=(\".*?\")(.*)size=(\".*?\")(.*)";
+
+    private Log logger;
+    private File nativeOutputDir;
+
+    public Workarounds(File nativeOutputDir, Log logger) {
+        this.logger = logger;
+        this.nativeOutputDir = nativeOutputDir;
+    }
+
+    public Log getLog() {
+        return logger;
+    }
+
+    protected void applyNativeLauncherWorkaround(String appName) {
+        // check appName containing any dots
+        boolean needsWorkaround = appName.contains(".");
+        if( !needsWorkaround ){
+            return;
+        }
+        // rename .cfg-file (makes it able to create running applications again, even within installer)
+        String newConfigFileName = appName.substring(0, appName.lastIndexOf("."));
+        Path appPath = nativeOutputDir.toPath().resolve(appName).resolve("app");
+        String configfileExtension = ".cfg";
+        Path oldConfigFile = appPath.resolve(appName + configfileExtension);
+        try{
+            Files.move(oldConfigFile, appPath.resolve(newConfigFileName + configfileExtension), StandardCopyOption.ATOMIC_MOVE);
+        } catch(IOException ex){
+            getLog().warn("Couldn't rename configfile. Please see issue #124 of the javafx-maven-plugin for further details.", ex);
+        }
+    }
+
+    protected Map<String, Long> getFileSizes(List<String> files) {
+        final Map<String, Long> fileSizes = new HashMap<>();
+        files.stream().forEach(relativeFilePath -> {
+            File file = new File(nativeOutputDir, relativeFilePath);
+            // add the size for each file
+            fileSizes.put(relativeFilePath, file.length());
+        });
+        return fileSizes;
+    }
+
+    public void fixFileSizesWithinGeneratedJNLPFiles() {
+        // after signing, we have to adjust sizes, because they have changed (since they are modified with the signature)
+        List<String> jarFiles = getJARFilesFromJNLPFiles();
+        Map<String, Long> newFileSizes = getFileSizes(jarFiles);
+        List<File> generatedJNLPFiles = getGeneratedJNLPFiles();
+        Pattern pattern = Pattern.compile(JNLP_JAR_PATTERN);
+        generatedJNLPFiles.forEach(file -> {
+            try{
+                List<String> allLines = Files.readAllLines(file.toPath());
+                List<String> newLines = new ArrayList<>();
+                allLines.stream().forEach(line -> {
+                    if( line.matches(JNLP_JAR_PATTERN) ){
+                        // get jar-file
+                        Matcher matcher = pattern.matcher(line);
+                        matcher.find();
+                        String rawJarName = matcher.group(2);
+                        String jarName = rawJarName.substring(1, rawJarName.length() - 1);
+                        if( newFileSizes.containsKey(jarName) ){
+                            // replace old size with new one
+                            newLines.add(line.replace(matcher.group(4), "\"" + newFileSizes.get(jarName) + "\""));
+                        } else {
+                            newLines.add(line);
+                        }
+                    } else {
+                        newLines.add(line);
+                    }
+                });
+                Files.write(file.toPath(), newLines, StandardOpenOption.TRUNCATE_EXISTING);
+            } catch(IOException ignored){
+                // NO-OP
+            }
+        });
+    }
+
+    public List<File> getGeneratedJNLPFiles() {
+        List<File> generatedFiles = new ArrayList<>();
+
+        // try-ressource, because walking on files is lazy, resulting in file-handler left open otherwise
+        try(Stream<Path> walkstream = Files.walk(nativeOutputDir.toPath())){
+            walkstream.forEach(fileEntry -> {
+                File possibleJNLPFile = fileEntry.toFile();
+                String fileName = possibleJNLPFile.getName();
+                if( fileName.endsWith(".jnlp") ){
+                    generatedFiles.add(possibleJNLPFile);
+                }
+            });
+        } catch(IOException ignored){
+            // NO-OP
+        }
+
+        return generatedFiles;
+    }
+
+    public List<String> getJARFilesFromJNLPFiles() {
+        List<String> jarFiles = new ArrayList<>();
+        getGeneratedJNLPFiles().stream().map(jnlpFile -> jnlpFile.toPath()).forEach(jnlpPath -> {
+            try{
+                List<String> allLines = Files.readAllLines(jnlpPath);
+                allLines.stream().filter(line -> line.trim().startsWith("<jar href=")).forEach(line -> {
+                    String jarFile = line.replaceAll(JNLP_JAR_PATTERN, "$2");
+                    jarFiles.add(jarFile.substring(1, jarFile.length() - 1));
+                });
+            } catch(IOException ignored){
+                // NO-OP
+            }
+        });
+        return jarFiles;
+    }
+
+    public void fixPathsInsideJNLPFiles() {
+        List<File> generatedJNLPFiles = getGeneratedJNLPFiles();
+        Pattern pattern = Pattern.compile(JNLP_JAR_PATTERN);
+        generatedJNLPFiles.forEach(file -> {
+            try{
+                List<String> allLines = Files.readAllLines(file.toPath());
+                List<String> newLines = new ArrayList<>();
+                allLines.stream().forEach(line -> {
+                    if( line.matches(JNLP_JAR_PATTERN) ){
+                        // get jar-file
+                        Matcher matcher = pattern.matcher(line);
+                        matcher.find();
+                        String rawJarName = matcher.group(2);
+                        // replace \ with /
+                        newLines.add(line.replace(rawJarName, rawJarName.replaceAll("\\\\", "\\/")));
+                    } else {
+                        newLines.add(line);
+                    }
+                });
+                Files.write(file.toPath(), newLines, StandardOpenOption.TRUNCATE_EXISTING);
+            } catch(IOException ignored){
+                // NO-OP
+            }
+        });
+    }
+
+    public void applyWorkaround205(Map<String, ? super Object> paramsToBundleWith) {
+        if( "prop".equals(paramsToBundleWith.get("launcher-cfg-format")) ){
+            // property-file format
+            // LinuxAppBundler
+            // writeCfgFile(p, rootDir);
+        } else {
+            // INI-file format
+            // AbstractImageBundler
+            // writeCfgFile(p, new File(rootDir, LinuxAppBundler.getLauncherCfgName(p)), LinuxAppBundler.getRuntimeLocation(p));
+        }
+        /*
+                            private String getRuntimeLocation(Map<String, ? super Object> params) {
+                                if (LINUX_RUNTIME.fetchFrom(params) == null) {
+                                    return "";
+                                } else {
+                                    return "$APPDIR/runtime";
+                                }
+                            }
+
+                            public static String getLauncherCfgName(Map<String, ? super Object> p) {
+                                return "app/" + APP_FS_NAME.fetchFrom(p) +".cfg";
+                            }
+         */
+    }
+
+    public void applyWorkaround124(String appName, List<NativeLauncher> secondaryLaunchers) {
+        // apply on main launcher
+        applyNativeLauncherWorkaround(appName);
+
+        // check on secondary launchers too
+        if( secondaryLaunchers != null && !secondaryLaunchers.isEmpty() ){
+            secondaryLaunchers.stream().map(launcher -> {
+                return launcher.getAppName();
+            }).filter(launcherAppName -> {
+                // check appName containing any dots (which is the bug)
+                return launcherAppName.contains(".");
+            }).forEach(launcherAppname -> {
+                applyNativeLauncherWorkaround(launcherAppname);
+            });
+        }
+    }
+
+    public void applyWorkaround185(boolean skipSizeRecalculationForJNLP185) {
+        if( !skipSizeRecalculationForJNLP185 ){
+            getLog().info("Fixing sizes of JAR files within JNLP-files");
+            fixFileSizesWithinGeneratedJNLPFiles();
+        } else {
+            getLog().info("Skipped fixing sizes of JAR files within JNLP-files");
+        }
+    }
+
+    public void applyWorkaround167(Map<String, Object> params) {
+        if( params.containsKey("runtime") ){
+            getLog().info("Applying workaround for oracle-jdk-bug since 1.8.0u60 regarding cfg-file-format");
+            // the problem is com.oracle.tools.packager.windows.WinAppBundler within createLauncherForEntryPoint-Method
+            // it does NOT respect runtime-setting while calling "writeCfgFile"-method of com.oracle.tools.packager.AbstractImageBundler
+            // since newer java versions (they added possability to have INI-file-format of generated cfg-file, since 1.8.0_60).
+            // Because we want to have backward-compatibility within java 8, we will use parameter-name as hardcoded string!
+            // Our workaround: use prop-file-format
+            params.put("launcher-cfg-format", "prop");
+        }
+    }
+}


### PR DESCRIPTION
When bundling native installer bundle for linux-systems (like CentOS), the existing workaround for issue #124 wasn't applied, because the native installer bundler calls the application bundler internally while generating [DEP-package](https://github.com/teamfx/openjfx-8u-dev-rt/blob/master/modules/fxpackager/src/main/java/com/oracle/tools/packager/linux/LinuxDebBundler.java#L330) or [RPM-package](https://github.com/teamfx/openjfx-8u-dev-rt/blob/master/modules/fxpackager/src/main/java/com/oracle/tools/packager/linux/LinuxRpmBundler.java#L257).

Moved the workarounds to separate class (upcoming refactoring may be possible).