### PR TITLE
Add some features and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Release Notes
 =============
 
+Version 8.6.0 (01-Sept-2016)
+
+New:
+* added new property `useEnvironmentRelativeExecutables` to make sure having the correct executables used, required when having multiple installations of java, just set this to false for using the JDK used for executing maven  (this got migrated from the [javafx-gradle-plugin](https://github.com/FibreFoX/javafx-gradle-plugin))
+* added new property `runAppParameter` for specifying application parameters passed to the execution call `java -jar` while developing your application (this fixes #176, because that issue got valid as the `mvn jfx:run` goal is valid again after the removal of the `exec-maven-plugin`)
+* added new property `runJavaParameter` for having additional settings passed to the execution call used for running your javafx-application, makes it possible to specify javassist-parameters now (and much more)
+
+Bugfixes:
+* fixed tests not running on MacOSX due to different paths exceptations (thanks @sa-wilson)
+
+Improvements:
+* cleanup of some unused parameters
+* fixed missing "s" inside description about `jfx:list-bundlers`-mojo
+
 
 Version 8.5.0 (30-May-2016)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Travis Build Status](https://travis-ci.org/javafx-maven-plugin/javafx-maven-plugin.svg?branch=master)](https://travis-ci.org/javafx-maven-plugin/javafx-maven-plugin)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/64700ul3m9y88agi/branch/master?svg=true)](https://ci.appveyor.com/project/FibreFoX/javafx-maven-plugin/branch/master)
 [![Maven Central](https://img.shields.io/maven-central/v/com.zenjava/javafx-maven-plugin.svg)](https://maven-badges.herokuapp.com/maven-central/com.zenjava/javafx-maven-plugin)
-[![Dependency Status](https://www.versioneye.com/java/com.zenjava:javafx-maven-plugin/8.5.0/badge.svg)](https://www.versioneye.com/java/com.zenjava:javafx-maven-plugin/8.5.0)
+[![Dependency Status](https://www.versioneye.com/java/com.zenjava:javafx-maven-plugin/8.6.0/badge.svg)](https://www.versioneye.com/java/com.zenjava:javafx-maven-plugin/8.6.0)
+
 
 
 JavaFX Maven Plugin
@@ -9,11 +10,12 @@ JavaFX Maven Plugin
 
 The JavaFX Maven Plugin provides a way to assemble distribution bundles for JavaFX applications (8+) from within Maven.
  
-For easy configuration please use our new website (currently getting updated/reworked):
+For easy configuration please use our new website (which needs to get updated/reworked again):
 **[http://javafx-maven-plugin.github.io](http://javafx-maven-plugin.github.io)**
 
 For (outdated) documentation/examples, your can look at archived website:
 **[https://web.archive.org/web/20141009064442/http://zenjava.com/javafx/maven/](https://web.archive.org/web/20141009064442/http://zenjava.com/javafx/maven/)**
+
 
 
 Quickstart for JavaFX JAR
@@ -25,7 +27,7 @@ Add this to your pom.xml within to your build-plugin:
 <plugin>
     <groupId>com.zenjava</groupId>
     <artifactId>javafx-maven-plugin</artifactId>
-    <version>8.5.0</version>
+    <version>8.6.0</version>
     <configuration>
         <mainClass>your.package.with.Launcher</mainClass>
     </configuration>
@@ -33,6 +35,7 @@ Add this to your pom.xml within to your build-plugin:
 ```
 
 To create your executable file with JavaFX-magic, call `mvn jfx:jar`. The jar-file will be placed at `target/jfx/app`.
+
 
 
 Quickstart for JavaFX native bundle
@@ -44,7 +47,7 @@ Add this to your pom.xml within to your build-plugin:
 <plugin>
     <groupId>com.zenjava</groupId>
     <artifactId>javafx-maven-plugin</artifactId>
-    <version>8.5.0</version>
+    <version>8.6.0</version>
     <configuration>
         <vendor>YourCompany</vendor>
         <mainClass>your.package.with.Launcher</mainClass>
@@ -87,32 +90,32 @@ Set version to new SNAPSHOT-version:
 ```
 
 *Some notes: as this isn't the main branch, a lot of features aren't present in that branch yet, deployment of new "-SNAPSHOT"-version are on-demand*
-**This is currently heavily outdated and will be updated June 2016**
+**This is currently heavily outdated**
+
 
 
 Last Release Notes
 ==================
 
-**Version 8.5.0 (30-May-2016)**
-
-Bugfixes:
-* updated workaround-detection for creating native bundles without JRE, because [it got fixed by latest Oracle JDK 1.8.0u92](http://www.oracle.com/technetwork/java/javase/2col/8u92-bugfixes-2949473.html)
-* added workaround for native linux launcher inside native linux installer bundle (DEB and RPM) not working, see issue [#205](https://github.com/javafx-maven-plugin/javafx-maven-plugin/issues/205) for more details on this (it's a come-back of the [issue 124](https://github.com/javafx-maven-plugin/javafx-maven-plugin/issues/124))
+**Version 8.6.0 (01-Sept-2016)**
 
 New:
-* added ability to write and use custom bundlers! This makes it possible to customize the work which is required for your bundling-process.
-* added new property to disable "native linux launcher inside native linux installer"-fix `<skipNativeLauncherWorkaround205>true</skipNativeLauncherWorkaround205>`
+* added new property `useEnvironmentRelativeExecutables` to make sure having the correct executables used, required when having multiple installations of java, just set this to false for using the JDK used for executing maven  (this got migrated from the [javafx-gradle-plugin](https://github.com/FibreFoX/javafx-gradle-plugin))
+* added new property `runAppParameter` for specifying application parameters passed to the execution call `java -jar` while developing your application (this fixes #176, because that issue got valid as the `mvn jfx:run` goal is valid again after the removal of the `exec-maven-plugin`)
+* added new property `runJavaParameter` for having additional settings passed to the execution call used for running your javafx-application, makes it possible to specify javassist-parameters now (and much more)
+
+Bugfixes:
+* fixed tests not running on MacOSX due to different paths exceptations (thanks @sa-wilson)
 
 Improvements:
-* added IT-project "23-simple-custom-bundler"
-* added IT-project "24-simple-custom-bundler-failed", which fails to use custom bundler, but does not fail (normal behaviour)
-* added IT-projects regarding workaround for issue 205 (currenty they do nothing, I still need to write some verify-beanshell files)
-* moved workarounds and workaround-detection into its own class (makes it a bit easier to concentrate on the main work inside NativeMojo)
+* cleanup of some unused parameters
+* fixed missing "s" inside description about `jfx:list-bundlers`-mojo
+
 
 
 (Not yet) Release(d) Notes
 ==========================
 
-upcoming Version 8.5.1 (???-2016)
+upcoming Version 8.6.1 (???-2016)
 
 * nothing changed yet

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.zenjava</groupId>
     <artifactId>javafx-maven-plugin</artifactId>
-    <version>8.5.1-SNAPSHOT</version>
+    <version>8.6.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -143,6 +143,12 @@
             <email>BTAN@MF110187.lafayette.micropole.com</email>
             <properties>
                 <github>boliang-micropole</github>
+            </properties>
+        </contributor>
+        <contributor>
+            <name>Scott Wilson</name>
+            <properties>
+                <github>sa-wilson</github>
             </properties>
         </contributor>
     </contributors>

--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
@@ -107,7 +107,7 @@ public abstract class AbstractJfxToolsMojo extends AbstractMojo {
      *
      * The default is to use environment relative executables.
      *
-     * @parameter property="environmentRelativeExecutables" default-value="true"
+     * @parameter property="useEnvironmentRelativeExecutables" default-value="true"
      */
     protected boolean useEnvironmentRelativeExecutables;
 

--- a/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/AbstractJfxToolsMojo.java
@@ -99,6 +99,18 @@ public abstract class AbstractJfxToolsMojo extends AbstractMojo {
      */
     protected String deployDir;
 
+    /**
+     * All commands executed by this Maven-plugin will be done using the current available commands
+     * of your maven-execution environment. It is possible to call Maven with a different version of Java,
+     * so these calls might be wrong. To use the executables of the JDK used for running this maven-plugin,
+     * please set this to false. You might need this in the case you installed multiple versions of Java.
+     *
+     * The default is to use environment relative executables.
+     *
+     * @parameter property="environmentRelativeExecutables" default-value="true"
+     */
+    protected boolean useEnvironmentRelativeExecutables;
+
     private PackagerLib packagerLib;
 
     public PackagerLib getPackagerLib() throws MojoExecutionException {
@@ -122,5 +134,16 @@ public abstract class AbstractJfxToolsMojo extends AbstractMojo {
             this.packagerLib = new PackagerLib();
         }
         return this.packagerLib;
+    }
+
+    protected String getEnvironmentRelativeExecutablePath() {
+        if( useEnvironmentRelativeExecutables ){
+            return "";
+        }
+
+        String jrePath = System.getProperty("java.home");
+        String jdkPath = jrePath + File.separator + ".." + File.separator + "bin" + File.separator;
+
+        return jdkPath;
     }
 }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.project.MavenProject;
 
 /**
  * Generates a development keysstore that can be used for signing web based distribution bundles based on POM settings.
@@ -39,7 +41,35 @@ import java.util.List;
  * @phase validate
  * @requiresDependencyResolution
  */
-public class GenerateKeyStoreMojo extends AbstractJfxToolsMojo {
+public class GenerateKeyStoreMojo extends AbstractMojo {
+
+    /**
+     * The Maven Project Object
+     *
+     * @parameter property="project"
+     * @required
+     * @readonly
+     */
+    protected MavenProject project;
+
+    /**
+     * Flag to turn on verbose logging. Set this to true if you are having problems and want more detailed information.
+     *
+     * @parameter property="verbose" default-value="false"
+     */
+    protected Boolean verbose;
+
+    /**
+     * All commands executed by this Maven-plugin will be done using the current available commands
+     * of your maven-execution environment. It is possible to call Maven with a different version of Java,
+     * so these calls might be wrong. To use the executables of the JDK used for running this maven-plugin,
+     * please set this to false. You might need this in the case you installed multiple versions of Java.
+     *
+     * The default is to use environment relative executables.
+     *
+     * @parameter property="useEnvironmentRelativeExecutables" default-value="true"
+     */
+    protected boolean useEnvironmentRelativeExecutables;
 
     @FunctionalInterface
     private interface RequiredFieldAlternativeCallback {
@@ -241,4 +271,14 @@ public class GenerateKeyStoreMojo extends AbstractJfxToolsMojo {
         }
     }
 
+    protected String getEnvironmentRelativeExecutablePath() {
+        if( useEnvironmentRelativeExecutables ){
+            return "";
+        }
+
+        String jrePath = System.getProperty("java.home");
+        String jdkPath = jrePath + File.separator + ".." + File.separator + "bin" + File.separator;
+
+        return jdkPath;
+    }
 }

--- a/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/GenerateKeyStoreMojo.java
@@ -15,13 +15,9 @@
  */
 package com.zenjava.javafx.maven.plugin;
 
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Organization;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
@@ -43,46 +39,13 @@ import java.util.List;
  * @phase validate
  * @requiresDependencyResolution
  */
-public class GenerateKeyStoreMojo extends AbstractMojo {
+public class GenerateKeyStoreMojo extends AbstractJfxToolsMojo {
 
     @FunctionalInterface
     private interface RequiredFieldAlternativeCallback {
 
         String getValue();
     }
-
-    /**
-     * The Maven Project Object
-     *
-     * @parameter property="project"
-     * @required
-     * @readonly
-     */
-    protected MavenProject project;
-
-    /**
-     * The Maven Session Object
-     *
-     * @parameter property="session"
-     * @required
-     * @readonly
-     */
-    protected MavenSession session;
-
-    /**
-     * The Maven PluginManager Object
-     *
-     * @component
-     * @required
-     */
-    protected BuildPluginManager pluginManager;
-
-    /**
-     * Flag to turn on verbose logging. Set this to true if you are having problems and want more detailed information.
-     *
-     * @parameter property="verbose" default-value="false"
-     */
-    protected Boolean verbose;
 
     /**
      * Set this to true to silently overwrite the keystore. If this is set to false (the default) then if a keystore
@@ -161,7 +124,6 @@ public class GenerateKeyStoreMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-
         if( keyStore.exists() ){
             if( overwriteKeyStore ){
                 if( !keyStore.delete() ){
@@ -227,7 +189,7 @@ public class GenerateKeyStoreMojo extends AbstractMojo {
 
             List<String> command = new ArrayList<>();
 
-            command.add("keytool");
+            command.add(getEnvironmentRelativeExecutablePath() + "keytool");
             command.add("-genkeypair");
             command.add("-keystore");
             command.add(keyStore.getPath());

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -760,7 +760,7 @@ public class NativeMojo extends AbstractJfxToolsMojo {
 
     private void signJar(File jarFile) throws MojoExecutionException {
         List<String> command = new ArrayList<>();
-        command.add("jarsigner");
+        command.add(getEnvironmentRelativeExecutablePath() + "jarsigner");
         command.add("-strict");
         command.add("-keystore");
         command.add(keyStore.getAbsolutePath());


### PR DESCRIPTION
This fixes #176 and brings in some new features like more control over how `mvn jfx:run` works. Brings not-yet reported issue about environment relative JDK executables which are called via ProcessBuilder.