### PR TITLE
use modified project.version as nativeReleaseVersion

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -424,6 +424,11 @@ public class NativeMojo extends AbstractJfxToolsMojo {
         try{
             Map<String, ? super Object> params = new HashMap<>();
 
+            if (nativeReleaseVersion == null) {
+                nativeReleaseVersion = project.getVersion().replaceAll("[^\\d.]", "");
+            }
+            params.put(StandardBundlerParam.VERSION.getID(), nativeReleaseVersion);
+            
             // make bundlers doing verbose output (might not always be as verbose as expected)
             params.put(StandardBundlerParam.VERBOSE.getID(), verbose);
 
@@ -432,7 +437,6 @@ public class NativeMojo extends AbstractJfxToolsMojo {
             });
 
             params.put(StandardBundlerParam.APP_NAME.getID(), appName);
-            params.put(StandardBundlerParam.VERSION.getID(), nativeReleaseVersion);
             params.put(StandardBundlerParam.VENDOR.getID(), vendor);
             params.put(StandardBundlerParam.SHORTCUT_HINT.getID(), needShortcut);
             params.put(StandardBundlerParam.MENU_HINT.getID(), needMenu);

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -152,8 +152,10 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     /**
      * The release version as passed to the native installer. It would be nice to just use the project's version number
      * but this must be a fairly traditional version string (like '1.34.5') with only numeric characters and dot
-     * separators, otherwise the JFX packaging tools bomb out. Because of that we default to ${project.version} with all
-     * illegal characters stripped.
+     * separators, otherwise the JFX packaging tools bomb out. We default to 1.0 in case you can't be bothered to set
+     * a version and don't really care.
+     * Normally all non-number signs and dots are removed from the value, which can be disabled
+     * by setting 'skipNativeVersionNumberSanitizing' to true.
      *
      * @parameter
      */
@@ -400,6 +402,11 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      */
     protected boolean skipJNLP = false;
 
+    /**
+     * @parameter default-value=false
+     */
+    protected boolean skipNativeVersionNumberSanitizing = false;
+
     protected Workarounds workarounds = null;
 
     private static final String CFG_WORKAROUND_MARKER = "cfgWorkaroundMarker";
@@ -424,11 +431,6 @@ public class NativeMojo extends AbstractJfxToolsMojo {
         try{
             Map<String, ? super Object> params = new HashMap<>();
 
-            if (nativeReleaseVersion == null) {
-                nativeReleaseVersion = project.getVersion().replaceAll("[^\\d.]", "");
-            }
-            params.put(StandardBundlerParam.VERSION.getID(), nativeReleaseVersion);
-            
             // make bundlers doing verbose output (might not always be as verbose as expected)
             params.put(StandardBundlerParam.VERBOSE.getID(), verbose);
 
@@ -437,6 +439,11 @@ public class NativeMojo extends AbstractJfxToolsMojo {
             });
 
             params.put(StandardBundlerParam.APP_NAME.getID(), appName);
+            params.put(StandardBundlerParam.VERSION.getID(), nativeReleaseVersion);
+            // replace that value
+            if( !skipNativeVersionNumberSanitizing && nativeReleaseVersion != null ){
+                params.put(StandardBundlerParam.VERSION.getID(), nativeReleaseVersion.replaceAll("[^\\d.]", ""));
+            }
             params.put(StandardBundlerParam.VENDOR.getID(), vendor);
             params.put(StandardBundlerParam.SHORTCUT_HINT.getID(), needShortcut);
             params.put(StandardBundlerParam.MENU_HINT.getID(), needMenu);

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -152,10 +152,10 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     /**
      * The release version as passed to the native installer. It would be nice to just use the project's version number
      * but this must be a fairly traditional version string (like '1.34.5') with only numeric characters and dot
-     * separators, otherwise the JFX packaging tools bomb out. We default to 1.0 in case you can't be bothered to set
-     * a version and don't really care.
+     * separators, otherwise the JFX packaging tools bomb out. Because of that we default to ${project.version} with all
+     * illegal characters stripped.
      *
-     * @parameter default-value="1.0"
+     * @parameter
      */
     private String nativeReleaseVersion;
 


### PR DESCRIPTION
Hi,

i wanted to use my project version as the nativeReleaseVersion. Since the javafx packaging tools do only allow numbers and dots i stripped all illegal characters.

I have seen this approach in https://github.com/javafx-maven-plugin/javafx-maven-plugin/pull/122 but it got rejected because he included multiple changes in one pull request.

maybe its worth a thought ;)