### PR TITLE
make it possible to add arguments to jarsigner-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ upcoming Version 8.8.0 (???-2016)
 
 New:
 * added detection of missing main class, wrong configuration now gets detected a bit earlier
+* signing jars using `jarsigner` was introduced some time ago, but it was lacking some custom parameters, this is now fixed by having the new `additionalJarsignerParameters`-list while using native-mojo (fixes issue #260)
 
 Improvements:
 * added warning when no classes were generated for `-jfx.jar`-generation, fixes issue #233 (no real FIX, as this is no real BUG ... IMHO)

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -403,9 +403,18 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     protected boolean skipJNLP = false;
 
     /**
-     * @parameter default-value=false
+     * @parameter property="skipNativeVersionNumberSanitizing" default-value=false
      */
     protected boolean skipNativeVersionNumberSanitizing = false;
+
+    /**
+     * Since it it possible to sign created jar-files using jarsigner, it might be required to
+     * add some special parameters for calling it (like -tsa and -tsacert). Just add them to this
+     * list to have them being applied.
+     *
+     * @parameter
+     */
+    private List<String> additionalJarsignerParameters = new ArrayList<>();
 
     protected Workarounds workarounds = null;
 
@@ -998,6 +1007,10 @@ public class NativeMojo extends AbstractJfxToolsMojo {
         command.add(keyPassword);
         command.add(jarFile.getAbsolutePath());
         command.add(keyStoreAlias);
+        Optional.ofNullable(additionalJarsignerParameters).ifPresent(jarsignerParameters -> {
+            command.addAll(jarsignerParameters);
+        });
+
         if( verbose ){
             command.add("-verbose");
         }
@@ -1007,6 +1020,10 @@ public class NativeMojo extends AbstractJfxToolsMojo {
                     .inheritIO()
                     .directory(project.getBasedir())
                     .command(command);
+
+            if( verbose ){
+                getLog().info("Running command: " + String.join(" ", command));
+            }
 
             getLog().info("Signing JAR files for jnlp bundle using jarsigner-method");
             Process p = pb.start();

--- a/src/main/java/com/zenjava/javafx/maven/plugin/RunMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/RunMojo.java
@@ -86,6 +86,11 @@ public class RunMojo extends AbstractJfxToolsMojo {
                     .inheritIO()
                     .directory(jfxAppOutputDir)
                     .command(command);
+
+            if( verbose ){
+                getLog().info("Running command: " + String.join(" ", command));
+            }
+
             Process p = pb.start();
             p.waitFor();
             if( p.exitValue() != 0 ){


### PR DESCRIPTION
The new introduced jarsigner requires customm options sometimes

Fixes #260