### PR TITLE
fixes arguments for secondary launchers not being set

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -571,7 +571,7 @@ public class NativeMojo extends AbstractJfxToolsMojo {
                             secondaryLauncher.put(StandardBundlerParam.USER_JVM_OPTIONS.getID(), new HashMap<>(userJvmOptions));
                         });
                         Optional.ofNullable(launcher.getLauncherArguments()).ifPresent(arguments -> {
-                            params.put(StandardBundlerParam.ARGUMENTS.getID(), new ArrayList<>(arguments));
+                            secondaryLauncher.put(StandardBundlerParam.ARGUMENTS.getID(), new ArrayList<>(arguments));
                         });
                         return secondaryLauncher;
                     }).collect(Collectors.toList()));


### PR DESCRIPTION
this got reported here: https://github.com/FibreFoX/javafx-gradle-plugin/issues/55