### PR TITLE
 Support for templates for JNLPBundler, and support for bundler parameters 'title' and 'description'

### DIFF
--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -186,6 +186,14 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      * @parameter property="jfx.bundleArguments"
      */
     protected Map<String, String> bundleArguments;
+    
+    /**
+     * The list of filenames of user-defined HTML templates.
+     * If no files are specified, then the default template will be used.
+     * 
+     * @parameter property="jfx.jnlpTemplates"
+     */
+    protected List<File> jnlpTemplates;
 
     /**
      * The name of the JavaFX packaged executable to be built into the 'native/bundles' directory. By default this will
@@ -196,6 +204,20 @@ public class NativeMojo extends AbstractJfxToolsMojo {
      * @parameter property="jfx.appName" default-value="${project.build.finalName}"
      */
     protected String appName;
+    
+    /**
+     * A description used within generated JNLP-file.
+     *
+     * @parameter property="jfx.description" default-value="${project.description}"
+     */
+    protected String description;
+    
+    /**
+     * A title used within generated JNLP-file.
+     *
+     * @parameter property="jfx.title" default-value="${project.name}"
+     */
+    protected String title;
 
     /**
      * Will be set when having goal "build-native" within package-phase and calling "jfx:native" from CLI. Internal usage only.
@@ -489,6 +511,8 @@ public class NativeMojo extends AbstractJfxToolsMojo {
             });
 
             params.put(StandardBundlerParam.APP_NAME.getID(), appName);
+            params.put(StandardBundlerParam.TITLE.getID(), title);
+            params.put(StandardBundlerParam.DESCRIPTION.getID(), description);
             params.put(StandardBundlerParam.VERSION.getID(), nativeReleaseVersion);
             // replace that value
             if( !skipNativeVersionNumberSanitizing && nativeReleaseVersion != null ){
@@ -728,6 +752,16 @@ public class NativeMojo extends AbstractJfxToolsMojo {
                                 getLog().warn("You missed to specify some bundleArguments-entry, please set 'jnlp.outfile', e.g. using appName.");
                                 continue;
                             }
+                        }
+                        
+                        if( "jnlp".equals(currentRunningBundlerID) ){
+                            Optional.ofNullable(jnlpTemplates).ifPresent(jnlpTemplates -> {
+                                final Map<File,File> _jnlpTemplates = new HashMap<>();
+                                for( File jnlpTemplate : jnlpTemplates ){
+                                    _jnlpTemplates.put(jnlpTemplate, new File(nativeOutputDir, jnlpTemplate.getName()));
+                                }
+                                paramsToBundleWith.put("jnlp.templates", _jnlpTemplates);
+                            });
                         }
 
                         // DO BUNDLE HERE ;) and don't get confused about all the other stuff

--- a/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
+++ b/src/main/java/com/zenjava/javafx/maven/plugin/NativeMojo.java
@@ -206,14 +206,14 @@ public class NativeMojo extends AbstractJfxToolsMojo {
     protected String appName;
     
     /**
-     * A description used within generated JNLP-file.
+     * A description used as bundler parameter; occurs for example within generated JNLP-file.
      *
      * @parameter property="jfx.description" default-value="${project.description}"
      */
     protected String description;
     
     /**
-     * A title used within generated JNLP-file.
+     * A title used as bundler parameter; occurs for example within generated JNLP-file.
      *
      * @parameter property="jfx.title" default-value="${project.name}"
      */


### PR DESCRIPTION
This is the third attempt to get my pull request accepted and integrated, after #94 and #122 were declined, and a feature proposed in #122 was later integrated in #255.

The commit I am asking you to integrate allows for three further bundler parameters:

- `jnlpTemplates` -- a list of HTML files to be processed as templates by `JNLPBundler`
- `title` -- a title to be used by any supporting bundler, and which defaults to `${project.name}`
- `description` -- a description to be used by any supporting bundler, and which defaults to `${project.description}`

Although @FibreFoX has integrated the option to specify `<bundleArguments>` and `jnlp.templates` is a [`StandardBundlerParam`](https://github.com/Debian/openjfx/blob/e32fd960e20c58c9b7db27e426b4bca6d52add2f/modules/fxpackager/src/main/java/com/oracle/tools/packager/StandardBundlerParam.java), cf. [`JNLPBundler`](https://github.com/Debian/openjfx/blob/master/modules/fxpackager/src/main/java/com/oracle/tools/packager/jnlp/JNLPBundler.java#L121), such a list of files cannot be parsed from the `pom.xml`, since a String converter is missing, see [`JNLPBundler`](https://github.com/Debian/openjfx/blob/master/modules/fxpackager/src/main/java/com/oracle/tools/packager/jnlp/JNLPBundler.java#L128).  My solution to this works as follows.

1. An optional list-valued field `jnlpTemplates` is defined in the `NativeMojo`.
2. A user may add several `<jnlpTemplate>` entries (within `<jnlpTemplates>`) pointing to files to be used as templates by the `JNLPBundler`.
3. When executing `NativeMojo` for the bundler `jnlp`, then this `List<File>` is converted into a `Map<File,File>`, see Lines 757-765, and the `Map<File,File>` is then added to `paramsToBundleWith` with key `jnlp.templates`.
4. After a successful execution of the `NativeMojo`, the processed HTML files can be found in `target/jfx/native`.

In case one needs further control on where to output and store the processed HTML files, one could extend the field `jnlpTemplates` to allow for the declaration of pairs of input and output files.  Currently, it is only a list of input files the names of which are used as names of the output files under `target/jfx/native`.